### PR TITLE
Use custom auto-type sequences if available

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Features
 
 - *NOTE* Only support .kdbx databases, not .kdb
 - Auto-type username and/or password on selection. No clipboard copy/paste
-  involved.
+  involved. Will use a custom auto-type sequence if you have one defined.
 - Select any single field and have it typed into the active window. Notes fields
   can be viewed line-by-line from within dmenu and the selected line will be
   typed when selected.

--- a/keepmenu
+++ b/keepmenu
@@ -343,6 +343,42 @@ def get_passphrase():
         password = dmenu_select(0, "Passphrase")
     return password
 
+def tokenize_autotype(autotype):
+    while len(autotype) > 0:
+        opening_idx = -1
+        for c in "{+^%~@":
+            idx = autotype.find(c)
+            if idx != -1 and (opening_idx == -1 or idx < opening_idx):
+                opening_idx = idx
+
+        if opening_idx == -1:
+            # found the end of the string without further opening braces or
+            # other characters
+            yield autotype, False
+            return
+
+        if opening_idx > 0:
+            yield autotype[:opening_idx], False
+
+        if autotype[opening_idx] in "+^%~@":
+            yield autotype[opening_idx], True
+            autotype = autotype[opening_idx+1:]
+            continue
+
+        closing_idx = autotype.find('}')
+        if closing_idx == -1:
+            dmenu_err("Unable to find matching right brace (}) while" +
+                      "tokenizing auto-type string: %s\n" % (autotype))
+            return
+        elif closing_idx == opening_idx + 1 and closing_idx + 1 < len(autotype) \
+                and autotype[closing_idx + 1] == '}':
+            yield "{}}", True
+            autotype = autotype[closing_idx+2:]
+            continue
+        else:
+            yield autotype[opening_idx:closing_idx+1], True
+
+        autotype = autotype[closing_idx+1:]
 
 def type_entry(entry):
     """Pick which library to use to type strings
@@ -350,53 +386,242 @@ def type_entry(entry):
     Defaults to pyuserinput
 
     """
+    sequence = "{USERNAME}{TAB}{PASSWORD}{ENTER}"
+    if hasattr(entry, 'autotype_sequence') and entry.autotype_sequence:
+        sequence = entry.autotype_sequence
+    tokens = tokenize_autotype(sequence)
+
     library = 'pyuserinput'
     if CONF.has_option('database', 'type_library'):
         library = CONF.get('database', 'type_library')
     if library == 'xdotool':
-        type_entry_xdotool(entry)
+        type_entry_xdotool(entry, tokens)
     else:
-        type_entry_pyuserinput(entry)
+        type_entry_pyuserinput(entry, tokens)
 
+placeholder_autotype_tokens = {
+    "{TITLE}"   : lambda e: e.title,
+    "{USERNAME}": lambda e: e.username,
+    "{URL}"     : lambda e: e.url,
+    "{PASSWORD}": lambda e: e.password,
+    "{NOTES}"   : lambda e: e.notes,
+}
 
-def type_entry_pyuserinput(entry):
-    """Use PyUserInput to type the selected entry username and/or password and
-    then 'Enter'.
+string_autotype_tokens = {
+    "{PLUS}"      : '+',
+    "{PERCENT}"   : '%',
+    "{CARET}"     : '^',
+    "{TILDE}"     : '~',
+    "{LEFTPAREN}" : '(',
+    "{RIGHTPAREN}": ')',
+    "{LEFTBRACE}" : '{',
+    "{RIGHTBRACE}": '}',
+    "{AT}"        : '@',
+    "{+}"         : '+',
+    "{%}"         : '%',
+    "{^}"         : '^',
+    "{~}"         : '~',
+    "{(}"         : '(',
+    "{)}"         : ')',
+    "{[}"         : '[',
+    "{]}"         : ']',
+    "{{}"         : '{',
+    "{}}"         : '}',
+}
+
+pyuserinput_autotype_tokens = {
+    "{TAB}"       : lambda kbd: kbd.tab_key,
+    "{ENTER}"     : lambda kbd: kbd.return_key,
+    "~"           : lambda kbd: kbd.return_key,
+    "{UP}"        : lambda kbd: kbd.up_key,
+    "{DOWN}"      : lambda kbd: kbd.down_key,
+    "{LEFT}"      : lambda kbd: kbd.left_key,
+    "{RIGHT}"     : lambda kbd: kbd.right_key,
+    "{INSERT}"    : lambda kbd: kbd.insert_key,
+    "{INS}"       : lambda kbd: kbd.insert_key,
+    "{DELETE}"    : lambda kbd: kbd.delete_key,
+    "{DEL}"       : lambda kbd: kbd.delete_key,
+    "{HOME}"      : lambda kbd: kbd.home_key,
+    "{END}"       : lambda kbd: kbd.end_key,
+    "{PGUP}"      : lambda kbd: kbd.page_up_key,
+    "{PGDN}"      : lambda kbd: kbd.page_down_key,
+    "{SPACE}"     : lambda kbd: kbd.space_key,
+    "{BACKSPACE}" : lambda kbd: kbd.backspace_key,
+    "{BS}"        : lambda kbd: kbd.backspace_key,
+    "{BKSP}"      : lambda kbd: kbd.backspace_key,
+    "{BREAK}"     : lambda kbd: kbd.break_key,
+    "{CAPSLOCK}"  : lambda kbd: kbd.caps_lock_key,
+    "{ESC}"       : lambda kbd: kbd.escape_key,
+    "{WIN}"       : lambda kbd: kbd.windows_l_key,
+    "{LWIN}"      : lambda kbd: kbd.windows_l_key,
+    "{RWIN}"      : lambda kbd: kbd.windows_r_key,
+    "{APPS}"      : lambda kbd: kbd.apps_key,
+    "{HELP}"      : lambda kbd: kbd.help_key,
+    "{NUMLOCK}"   : lambda kbd: kbd.num_lock_key,
+    "{PRTSC}"     : lambda kbd: kbd.print_screen_key,
+    "{SCROLLLOCK}": lambda kbd: kbd.scroll_lock_key,
+    "{F1}"        : lambda kbd: kbd.function_keys[1],
+    "{F2}"        : lambda kbd: kbd.function_keys[2],
+    "{F3}"        : lambda kbd: kbd.function_keys[3],
+    "{F4}"        : lambda kbd: kbd.function_keys[4],
+    "{F5}"        : lambda kbd: kbd.function_keys[5],
+    "{F6}"        : lambda kbd: kbd.function_keys[6],
+    "{F7}"        : lambda kbd: kbd.function_keys[7],
+    "{F8}"        : lambda kbd: kbd.function_keys[8],
+    "{F9}"        : lambda kbd: kbd.function_keys[9],
+    "{F10}"       : lambda kbd: kbd.function_keys[10],
+    "{F11}"       : lambda kbd: kbd.function_keys[11],
+    "{F12}"       : lambda kbd: kbd.function_keys[12],
+    "{F13}"       : lambda kbd: kbd.function_keys[13],
+    "{F14}"       : lambda kbd: kbd.function_keys[14],
+    "{F15}"       : lambda kbd: kbd.function_keys[15],
+    "{F16}"       : lambda kbd: kbd.function_keys[16],
+    "{ADD}"       : lambda kbd: kbd.numpad_keys['Add'],
+    "{SUBTRACT}"  : lambda kbd: kbd.numpad_keys['Subtract'],
+    "{MULTIPLY}"  : lambda kbd: kbd.numpad_keys['Multiply'],
+    "{DIVIDE}"    : lambda kbd: kbd.numpad_keys['Divide'],
+    "{NUMPAD0}"   : lambda kbd: kbd.numpad_keys['0'],
+    "{NUMPAD1}"   : lambda kbd: kbd.numpad_keys['1'],
+    "{NUMPAD2}"   : lambda kbd: kbd.numpad_keys['2'],
+    "{NUMPAD3}"   : lambda kbd: kbd.numpad_keys['3'],
+    "{NUMPAD4}"   : lambda kbd: kbd.numpad_keys['4'],
+    "{NUMPAD5}"   : lambda kbd: kbd.numpad_keys['5'],
+    "{NUMPAD6}"   : lambda kbd: kbd.numpad_keys['6'],
+    "{NUMPAD7}"   : lambda kbd: kbd.numpad_keys['7'],
+    "{NUMPAD8}"   : lambda kbd: kbd.numpad_keys['8'],
+    "{NUMPAD9}"   : lambda kbd: kbd.numpad_keys['9'],
+    "+"           : lambda kbd: kbd.shift_key,
+    "^"           : lambda kbd: kbd.control_key,
+    "%"           : lambda kbd: kbd.alt_key,
+    "@"           : lambda kbd: kbd.windows_l_key,
+}
+
+def type_entry_pyuserinput(entry, tokens):
+    """Use PyUserInput to auto-type the selected entry
 
     """
     kbd = PyKeyboard()
-    if entry.username:
-        try:
-            kbd.type_string(entry.username)
-        except (X11Error, KeyError):
-            dmenu_err("Unable to type string...bad character.\n"
-                      "Try setting `type_library = xdotool` in config.ini")
-            return
-        if entry.password:
-            kbd.tap_key(kbd.tab_key)
-    if entry.password:
-        try:
-            kbd.type_string(entry.password)
-        except (X11Error, KeyError):
-            dmenu_err("Unable to type string...bad character.\n"
-                      "Try setting `type_library = xdotool` in config.ini")
-            return
-    # Not sure why we need n=2, but only seems to work that way
-    kbd.tap_key(kbd.enter_key, n=2)
+    for token, special in tokens:
+        if special:
+            if token in placeholder_autotype_tokens:
+                to_type = placeholder_autotype_tokens[token](entry)
+                if to_type:
+                    try:
+                        kbd.type_string(to_type)
+                    except (X11Error, KeyError):
+                        dmenu_err("Unable to type string...bad character.\n"
+                                  "Try setting `type_library = xdotool` in config.ini")
+                        return
+            elif token in string_autotype_tokens:
+                to_type = string_autotype_tokens[token]
+                try:
+                    kbd.type_string(to_type)
+                except (X11Error, KeyError):
+                    dmenu_err("Unable to type string...bad character.\n"
+                              "Try setting `type_library = xdotool` in config.ini")
+                    return
+            elif token in pyuserinput_autotype_tokens:
+                to_tap = pyuserinput_autotype_tokens[token](kbd)
+                kbd.tap_key(to_tap)
+            else:
+                dmenu_err("Unsupported auto-type token (pyuserinput): \"%s\"" % (token))
+                return
+        else:
+            try:
+                kbd.type_string(token)
+            except (X11Error, KeyError):
+                dmenu_err("Unable to type string...bad character.\n"
+                          "Try setting `type_library = xdotool` in config.ini")
+                return
 
+xdotool_autotype_tokens = {
+    "{TAB}"       : ['key', 'Tab'],
+    "{ENTER}"     : ['key', 'Return'],
+    "~"           : ['key', 'Return'],
+    "{UP}"        : ['key', 'Up'],
+    "{DOWN}"      : ['key', 'Down'],
+    "{LEFT}"      : ['key', 'Left'],
+    "{RIGHT}"     : ['key', 'Right'],
+    "{INSERT}"    : ['key', 'Insert'],
+    "{INS}"       : ['key', 'Insert'],
+    "{DELETE}"    : ['key', 'Delete'],
+    "{DEL}"       : ['key', 'Delete'],
+    "{HOME}"      : ['key', 'Home'],
+    "{END}"       : ['key', 'End'],
+    "{PGUP}"      : ['key', 'Page_Up'],
+    "{PGDN}"      : ['key', 'Page_Down'],
+    "{SPACE}"     : ['type', ' '],
+    "{BACKSPACE}" : ['key', 'BackSpace'],
+    "{BS}"        : ['key', 'BackSpace'],
+    "{BKSP}"      : ['key', 'BackSpace'],
+    "{BREAK}"     : ['key', 'Break'],
+    "{CAPSLOCK}"  : ['key', 'Caps_Lock'],
+    "{ESC}"       : ['key', 'Escape'],
+    "{WIN}"       : ['key', 'Super'],
+    "{LWIN}"      : ['key', 'Super_L'],
+    "{RWIN}"      : ['key', 'Super_R'],
+#    "{APPS}"      : ['key', ''],
+#    "{HELP}"      : ['key', ''],
+    "{NUMLOCK}"   : ['key', 'Num_Lock'],
+#    "{PRTSC}"     : ['key', ''],
+    "{SCROLLLOCK}": ['key', 'Scroll_Lock'],
+    "{F1}"        : ['key', 'F1'],
+    "{F2}"        : ['key', 'F2'],
+    "{F3}"        : ['key', 'F3'],
+    "{F4}"        : ['key', 'F4'],
+    "{F5}"        : ['key', 'F5'],
+    "{F6}"        : ['key', 'F6'],
+    "{F7}"        : ['key', 'F7'],
+    "{F8}"        : ['key', 'F8'],
+    "{F9}"        : ['key', 'F9'],
+    "{F10}"       : ['key', 'F10'],
+    "{F11}"       : ['key', 'F11'],
+    "{F12}"       : ['key', 'F12'],
+    "{F13}"       : ['key', 'F13'],
+    "{F14}"       : ['key', 'F14'],
+    "{F15}"       : ['key', 'F15'],
+    "{F16}"       : ['key', 'F16'],
+    "{ADD}"       : ['key', 'KP_Add'],
+    "{SUBTRACT}"  : ['key', 'KP_Subtract'],
+    "{MULTIPLY}"  : ['key', 'KP_Multiply'],
+    "{DIVIDE}"    : ['key', 'KP_Divide'],
+    "{NUMPAD0}"   : ['key', 'KP_0'],
+    "{NUMPAD1}"   : ['key', 'KP_1'],
+    "{NUMPAD2}"   : ['key', 'KP_2'],
+    "{NUMPAD3}"   : ['key', 'KP_3'],
+    "{NUMPAD4}"   : ['key', 'KP_4'],
+    "{NUMPAD5}"   : ['key', 'KP_5'],
+    "{NUMPAD6}"   : ['key', 'KP_6'],
+    "{NUMPAD7}"   : ['key', 'KP_7'],
+    "{NUMPAD8}"   : ['key', 'KP_8'],
+    "{NUMPAD9}"   : ['key', 'KP_9'],
+    "+"           : ['key', 'Shift'],
+    "^"           : ['Key', 'Ctrl'],
+    "%"           : ['key', 'Alt'],
+    "@"           : ['key', 'Super'],
+}
 
-def type_entry_xdotool(entry):
-    """Type entry username/password using xdotool
+def type_entry_xdotool(entry, tokens):
+    """Auto-type entry entry using xdotool
 
     """
-    if entry.username:
-        call(['xdotool', 'type', entry.username])
-        if entry.password:
-            call(['xdotool', 'key', 'Tab'])
-    if entry.password:
-        call(['xdotool', 'type', entry.password])
-    call(['xdotool', 'key', 'Return'])
-
+    for token, special in tokens:
+        if special:
+            if token in placeholder_autotype_tokens:
+                to_type = placeholder_autotype_tokens[token](entry)
+                if to_type:
+                    call(['xdotool', 'type', to_type])
+            elif token in string_autotype_tokens:
+                to_type = string_autotype_tokens[token]
+                call(['xdotool', 'type', to_type])
+            elif token in xdotool_autotype_tokens:
+                cmd = ['xdotool'] + xdotool_autotype_tokens[token]
+                call(cmd)
+            else:
+                dmenu_err("Unsupported auto-type token (xdotool): \"%s\"" % (token))
+                return
+        else:
+            call(['xdotool', 'type', token])
 
 def type_text(data):
     """Type the given text data

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -162,7 +162,46 @@ class TestFunctions(unittest.TestCase):
         kpo = KM.get_entries(database)
         self.assertIsInstance(kpo, KM.PyKeePass)
 
+    def test_tokenize_autotype(self):
+        """Test tokenizing autotype strings
+        """
+        tokens = [t for t in KM.tokenize_autotype("blah{SOMETHING}")]
+        self.assertEqual(len(tokens), 2)
+        self.assertEqual(tokens[0], ("blah", False))
+        self.assertEqual(tokens[1], ("{SOMETHING}", True))
 
+        tokens = [t for t in KM.tokenize_autotype("/abc{USERNAME}{ENTER}{TAB}{TAB} {SOMETHING}")]
+        self.assertEqual(len(tokens), 7)
+        self.assertEqual(tokens[0], ("/abc", False))
+        self.assertEqual(tokens[1], ("{USERNAME}", True))
+        self.assertEqual(tokens[4], ("{TAB}", True))
+        self.assertEqual(tokens[5], (" ", False))
+        self.assertEqual(tokens[6], ("{SOMETHING}", True))
+
+        tokens = [t for t in KM.tokenize_autotype("?{}}blah{{}{}}")]
+        self.assertEqual(len(tokens), 5)
+        self.assertEqual(tokens[0], ("?", False))
+        self.assertEqual(tokens[1], ("{}}", True))
+        self.assertEqual(tokens[2], ("blah", False))
+        self.assertEqual(tokens[3], ("{{}", True))
+        self.assertEqual(tokens[4], ("{}}", True))
+
+        tokens = [t for t in KM.tokenize_autotype("{DELAY 5}b{DELAY=50}")]
+        self.assertEqual(len(tokens), 3)
+        self.assertEqual(tokens[0], ("{DELAY 5}", True))
+        self.assertEqual(tokens[1], ("b", False))
+        self.assertEqual(tokens[2], ("{DELAY=50}", True))
+
+        tokens = [t for t in KM.tokenize_autotype("+{DELAY 5}plus^carat~@{}}")]
+        self.assertEqual(len(tokens), 8)
+        self.assertEqual(tokens[0], ("+", True))
+        self.assertEqual(tokens[1], ("{DELAY 5}", True))
+        self.assertEqual(tokens[2], ("plus", False))
+        self.assertEqual(tokens[3], ("^", True))
+        self.assertEqual(tokens[4], ("carat", False))
+        self.assertEqual(tokens[5], ("~", True))
+        self.assertEqual(tokens[6], ("@", True))
+        self.assertEqual(tokens[7], ("{}}", True))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Look up the auto-type sequence using pykeepass if it's available and use
it instead of the default. This does not support the *full* range of
auto-type functionality, as documented at
https://keepass.info/help/base/autotype.html, but attempts to implement
the most commonly-used.

Note that this is only enabled by a recent commit to pykeepass: https://github.com/pschmitt/pykeepass/pull/110/commits/dc189104615df31ebee6e7c8db4670fbc880eeba. You'll need a very recent version of pykeepass to enable custom auto-type sequences, but keepmenu will fall back to the default sequence if it's using an older version of pykeepass.