### PR TITLE
Don't crash when emptying Notes field

### DIFF
--- a/keepmenu
+++ b/keepmenu
@@ -1044,7 +1044,7 @@ def edit_notes(note):
         call(editor)
         fname.seek(0)
         note = fname.read()
-    note = None if not note else note.decode(ENC)
+    note = '' if not note else note.decode(ENC)
     return note
 
 


### PR DESCRIPTION
Before this change, I see the following if I attempt to edit a Notes
field via editor and leave it empty:

    Process DmenuRunner-2:
    Traceback (most recent call last):
      File "/usr/bin/keepmenu", line 1258, in <module>
	MANAGER = client()
      File "/usr/bin/keepmenu", line 1071, in client
	mgr.connect()
      File "/usr/lib/python3.7/multiprocessing/managers.py", line 512, in connect
	conn = Client(self._address, authkey=self._authkey)
      File "/usr/lib/python3.7/multiprocessing/connection.py", line 492, in Client
	c = SocketClient(address)
      File "/usr/lib/python3.7/multiprocessing/connection.py", line 619, in SocketClient
	s.connect(address)
    ConnectionRefusedError: [Errno 111] Connection refused

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "/usr/lib/python3.7/multiprocessing/process.py", line 297, in _bootstrap
	self.run()
      File "/usr/bin/keepmenu", line 1106, in run
	self.dmenu_run()
      File "/usr/bin/keepmenu", line 1181, in dmenu_run
	edit = edit_entry(self.kpo, entry)
      File "/usr/bin/keepmenu", line 1008, in edit_entry
	setattr(kp_entry, field, sel)
      File "/usr/lib/python3.7/site-packages/pykeepass/entry.py", line 159, in notes
	return self._set_string_field('Notes', value)
      File "/usr/lib/python3.7/site-packages/pykeepass/entry.py", line 91, in _set_string_field
	self._element.append(E.String(E.Key(key), E.Value(value)))
      File "src/lxml/builder.py", line 226, in lxml.builder.ElementMaker.__call__
    TypeError: bad argument type: NoneType(None)

This is an attempt to address https://github.com/firecat53/keepmenu/issues/34