### PR TITLE
Added support for {DELAY x} command.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,7 +83,8 @@ Installation
   + Adjust `pw_cache_period_min` if desired. Default is 6 hours (360 min).
   + Set the dmenu_command to `rofi` if you are using that instead
   + Adjust the autotype_default, if desired. Allowed codes are the
-    `Keepass 2.x codes`_ except for repetitions and command codes (DELAY, etc.).
+    `Keepass 2.x codes`_ except for repetitions and some command codes
+    (CLEARFIELD, etc.).
     Individual autotype sequences can be edited or disabled inside Keepmenu.
   + Set `type_library = xdotool` if you need support for non-U.S. English
     keyboard layouts and/or characters.

--- a/keepmenu
+++ b/keepmenu
@@ -19,6 +19,7 @@ from subprocess import call, Popen, PIPE
 import tempfile
 from threading import Timer
 import time
+import re
 import webbrowser
 import construct
 from pykeyboard import PyKeyboard
@@ -429,6 +430,25 @@ def tokenize_autotype(autotype):
 
         autotype = autotype[closing_idx+1:]
 
+def token_command(token):
+    """When token denotes a special command, this function provides a callable
+    implementing its behaviour.
+
+    """
+    cmd = None
+
+    def _check_delay():
+        match = re.match('{DELAY (\d+)}', token)
+        if match:
+            delay = match.group(1)
+            nonlocal cmd
+            cmd = lambda t=delay: time.sleep(int(t) / 1000)
+            return True
+        return False
+
+    if _check_delay():  # {DELAY x}
+        return cmd
+    return None
 
 def type_entry(entry):
     """Pick which library to use to type strings
@@ -563,7 +583,10 @@ def type_entry_pyuserinput(entry, tokens):
     enter_idx = True
     for token, special in tokens:
         if special:
-            if token in PLACEHOLDER_AUTOTYPE_TOKENS:
+            cmd = token_command(token)
+            if callable(cmd):
+                cmd()
+            elif token in PLACEHOLDER_AUTOTYPE_TOKENS:
                 to_type = PLACEHOLDER_AUTOTYPE_TOKENS[token](entry)
                 if to_type:
                     try:
@@ -675,7 +698,10 @@ def type_entry_xdotool(entry, tokens):
     enter_idx = True
     for token, special in tokens:
         if special:
-            if token in PLACEHOLDER_AUTOTYPE_TOKENS:
+            cmd = token_command(token)
+            if callable(cmd):
+                cmd()
+            elif token in PLACEHOLDER_AUTOTYPE_TOKENS:
                 to_type = PLACEHOLDER_AUTOTYPE_TOKENS[token](entry)
                 if to_type:
                     call(['xdotool', 'type', to_type])
@@ -771,7 +797,10 @@ def type_entry_ydotool(entry, tokens):
     enter_idx = True
     for token, special in tokens:
         if special:
-            if token in PLACEHOLDER_AUTOTYPE_TOKENS:
+            cmd = token_command(token)
+            if callable(cmd):
+                cmd()
+            elif token in PLACEHOLDER_AUTOTYPE_TOKENS:
                 to_type = PLACEHOLDER_AUTOTYPE_TOKENS[token](entry)
                 if to_type:
                     call(['ydotool', 'type', to_type])

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -212,5 +212,15 @@ class TestFunctions(unittest.TestCase):
         self.assertEqual(tokens[6], ("@", True))
         self.assertEqual(tokens[7], ("{}}", True))
 
+    def test_token_command(self):
+        self.assertTrue(callable(KM.token_command('{DELAY 5}')))
+        self.assertFalse(callable(KM.token_command('{DELAY 5 }')))
+        self.assertFalse(callable(KM.token_command('{DELAY 5')))
+        self.assertFalse(callable(KM.token_command('{DELAY a }')))
+        self.assertFalse(callable(KM.token_command('{DELAY }')))
+        self.assertFalse(callable(KM.token_command('{DELAY}')))
+        self.assertFalse(callable(KM.token_command('DELAY 5}')))
+        self.assertFalse(callable(KM.token_command('{DELAY a}')))
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Hi,

I implemented a support for `{DELAY x}` command, which delays autotype at the point of the token by `x` milliseconds. This is necessary for many web forms which presents username/password fields in several steps and between each step some kind of delay (e.g. from animation) can occur. This might be useful as well to wait after autotyping credentials, but before pressing `{ENTER}`, because otherwise sometimes some forms receive empty or incomplete credentials for some reason.