### PR TITLE
Implement configurable char presets for password generation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,8 +36,9 @@ Features
 - Hide selected groups from the default and 'View/Type Individual entries' views.
 - Keepmenu runs in the background after initial startup and will retain the
   entered passphrase for `pw_cache_period_min` minutes after the last activity.
-- Configure the characters used during password generation in the config or on
-  the fly (rofi only)
+- Configure the characters and groups of characters used during password
+  generation in the config file (see config.ini.example for instructions).
+  Multiple character sets can be selected on the fly when using Rofi.
 - Optional Pinentry support for secure passphrase entry.
 
 License
@@ -48,7 +49,8 @@ License
 Requirements
 ------------
 
-1. Python 3.4+
+1. Python 3.4+. *Note* Python 3.6+ uses the `secrets` module for password
+   generation to improve security.
 2. Pykeepass_ and PyUserInput_. Install via pip or your distribution's package
    manager, if available.
 3. Dmenu. Basic support is included for Rofi_, but most Rofi
@@ -106,6 +108,15 @@ Installation
   [dmenu_passphrase] section of config.ini will override those in [dmenu] so you
   can, for example, set the normal foreground and background colors to be the
   same to obscure the passphrase.
+- New sets of characters can be set in config.ini in the `[password_chars]`
+  section. A new preset for each custom set will be listed in addition to the
+  default presets. If you redefine one of the default sets (upper, lower,
+  digits, punctuation), it will replace the default values.
+- New preset groups of character sets can be defined in config.ini in the
+  `[password_char_presets]` section. You can set any combination of default and
+  custom character sets. A minimum of one character from each distinct set will
+  be used when generating a new password. If any custom presets are defined, the
+  default presets will not be displayed unless they are uncommented.
 
 .. Warning:: If you choose to store your database password into config.ini, make
    sure to `chmod 600 config.ini`. This is not secure and I only added it as a

--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,8 @@ Features
 - Hide selected groups from the default and 'View/Type Individual entries' views.
 - Keepmenu runs in the background after initial startup and will retain the
   entered passphrase for `pw_cache_period_min` minutes after the last activity.
+- Configure the characters used during password generation in the config or on
+  the fly (rofi only)
 - Optional Pinentry support for secure passphrase entry.
 
 License

--- a/config.ini.example
+++ b/config.ini.example
@@ -43,8 +43,31 @@
 ## Set the default autotype sequence (https://keepass.info/help/base/autotype.html#autoseq)
 # autotype_default = {USERNAME}{TAB}{PASSWORD}{ENTER}
 
-# [password]
-# Set character presets for password generation, for multiple use a whitespace in between
-# Valid values are: letters digits braces punctuation quotes dashes mathsym logograms
-# some_name = letters digits braces punctuation quotes dashes mathsym logograms
-# some_other_name = letters digits
+[password_chars]
+# Set custom groups of characters for password generation. Any name is fine and
+# these can be used to create new groups of presets in password_char_presets. If
+# you reuse 'upper', 'lower', 'digits', or 'punctuation', those will
+# replace the default values.
+# Defaults:
+# lower = abcdefghijklmnopqrstuvwxyz
+# upper = ABCDEFGHIJKLMNOPQRSTUVWXYZ
+# digits = 0123456789
+# NOTE: remember that % needs to be escaped with another % sign
+# punctuation = !"#$%%&'()*+,-./:;<=>?@[\]^_`{|}~
+# EXAMPLES:
+# punc min = !?#*@-+$%%
+# upper = ABCDEFZ
+
+[password_char_presets]
+# Set character preset groups for password generation. For multiple sets use a space in between
+# If you set any custom presets here, the default sets will not be displayed unless uncommented below:
+# Valid values are: upper lower digits punctuation
+# Also valid are any custom sets defined in [password_chars]
+# Defaults:
+# Letters+Digits+Punctuation = upper lower digits punctuation
+# Letters+Digits = upper lower digits
+# Letters = upper lower
+# Digits = digits
+# Custom Examples:
+# Minimal Punc = upper lower digits "punc min"
+# Router Site = upper digits

--- a/config.ini.example
+++ b/config.ini.example
@@ -42,3 +42,7 @@
 
 ## Set the default autotype sequence (https://keepass.info/help/base/autotype.html#autoseq)
 # autotype_default = {USERNAME}{TAB}{PASSWORD}{ENTER}
+
+# [password]
+# some_name = letters+digits+braces+punctuation+quotes+dashes+mathsym+logograms
+# some_other_name = letters+digits

--- a/config.ini.example
+++ b/config.ini.example
@@ -44,5 +44,7 @@
 # autotype_default = {USERNAME}{TAB}{PASSWORD}{ENTER}
 
 # [password]
-# some_name = letters+digits+braces+punctuation+quotes+dashes+mathsym+logograms
-# some_other_name = letters+digits
+# Set character presets for password generation, for multiple use a whitespace in between
+# Valid values are: letters digits braces punctuation quotes dashes mathsym logograms
+# some_name = letters digits braces punctuation quotes dashes mathsym logograms
+# some_other_name = letters digits

--- a/keepmenu
+++ b/keepmenu
@@ -284,7 +284,7 @@ def get_password_chars():
                 continue
     input_b = "\n".join(presets).encode(ENC)
     char_sel = dmenu_select(len(presets),
-                            "Pick character set(s) to use:", inp=input_b)
+                            "Pick character set(s) to use", inp=input_b)
     # This dictionary return also handles Rofi multiple select
     return {k: presets[k] for k in char_sel.split('\n')} if char_sel else False
 

--- a/keepmenu
+++ b/keepmenu
@@ -273,23 +273,23 @@ def get_pass_settings():
 CHAR_TYPES = {
     "letters" : string.ascii_letters,
     "digits" : string.digits,
-    "braces" : "(){}[]",
-    "punctuation" : ".,:;",
-    "quotes" : "\"'",
-    "dashes" : "\\-|_/",
-    "mathsym" : "<*+!?=",
-    "logograms" : "#$%&@^`~",
+    "braces" : '(){}[]',
+    "punctuation" : '.,:;',
+    "quotes" : '"\'',
+    "dashes" : '\\-|_/',
+    "mathsym" : '<*+!?=',
+    "logograms" : '#$%&@^`~',
 }
 
 REGEX_TYPES = {
-    "letters" : "[a-zA-Z]+",
-    "digits" : "[0-9]+",
-    "braces" : "[(){}\[\]]+",
-    "punctuation" : "[.,:;]+",
-    "quotes" : "[\"']+",
-    "dashes" : "[\\-|_/]+",
-    "mathsym" : "[<*+!?=]+",
-    "logograms" : "[#$%&@^`~]+",
+    "letters" : r'[a-zA-Z]+',
+    "digits" : r'[0-9]+',
+    "braces" : r'[(){}\[\]]+',
+    "punctuation" : r'[.,:;]+',
+    "quotes" : r'["\']+',
+    "dashes" : r'[\\-|_/]+',
+    "mathsym" : r'[<*+!?=]+',
+    "logograms" : r'[#$%&@^`~]+',
 }
 
 def get_database():

--- a/keepmenu
+++ b/keepmenu
@@ -64,17 +64,14 @@ def gen_passwd(length=20, alphabet_list=None):
 
     """
     if alphabet_list is None:
-        alphabet_list = ["letters", "digits", "braces"]
+        alphabet_list = CHARGROUPS_.keylist()
     length = max(4, length)
-    if set(alphabet_list).difference(set(CHARGROUPS_.keys())):
-        for alpha_set in set(alphabet_list).difference(set(CHARGROUPS_.keys())):
-            alphabet_list.remove(alpha_set)
+    alphabet_list = set(alphabet_list).intersection(CHARGROUPS_.keylist())
     alphabet = ''.join(CHARGROUPS_.get_chars(al) for al in alphabet_list)
     if len(alphabet_list) > length:
         return "Error: not all character sets used. Please edit config.ini"
-
     if not alphabet:
-        alphabet = ''.join(list(CHARGROUPS_.chars()))
+        alphabet = ''.join(list(CHARGROUPS_.chars))
     while True:
         password = ''.join(random.SystemRandom().choice(alphabet) for i in range(length))
         count = 0
@@ -85,7 +82,7 @@ def gen_passwd(length=20, alphabet_list=None):
     return password
 
 
-CONFIG_ = {'ROFI': False}
+CONFIG_ = {'ROFI': False, 'SETS': {}}
 
 
 def process_config():
@@ -156,6 +153,10 @@ def process_config():
                 dmenu_err("Ydotool not installed.\n"
                           "Please install or remove that option from config.ini")
                 sys.exit()
+    if CONF.has_section("password"):
+        CONFIG_["SETS"] = get_passwd_settings()
+    else:
+        CONFIG_["SETS"] = default_passwd_sets()
 
 
 def get_auth():
@@ -253,6 +254,21 @@ def dmenu_err(prompt):
     return dmenu_select(1, prompt)
 
 
+def default_passwd_sets():
+    """
+    Returns a default dict of password sets"""
+    presets = {}
+    presets["letters+digits+punctuation"] = ["letters",
+                                             "digits",
+                                             "braces",
+                                             "punctuation",
+                                             "quotes",
+                                             "dashes",
+                                             "mathsym",
+                                             "logograms"]
+    presets["letters+digits"] = ["letters", "digits"]
+    presets["letters"] = ["letters"]
+    return presets
 
 def get_passwd_settings():
     """
@@ -270,23 +286,14 @@ def get_passwd_settings():
             passwd_set = set()
             for group in groups:
                 group = group.strip()
-                if group in CHARGROUPS_.keys():
+                if group in CHARGROUPS_.keylist():
                     passwd_set.add(group)
                 else:
-                    # TODO This should end keepmenu
-                    dmenu_err(f"Error in password preset {key}")
+                    dmenu_err(f"Error: Unknown value in preset {key}")
+                    sys.exit()
                 presets[key] = list(passwd_set)
     if not presets:
-        presets["letters+digits+punctuation"] = ["letters",
-                                                 "digits",
-                                                 "braces",
-                                                 "punctuation",
-                                                 "quotes",
-                                                 "dashes",
-                                                 "mathsym",
-                                                 "logograms"]
-        presets["letters+digits"] = ["letters", "digits"]
-        presets["letters"] = ["letters"]
+        presets = default_passwd_sets()
     return presets
 
 
@@ -294,52 +301,53 @@ class CharGroups:
     """
     Class for using character groups throughout this module"""
     def __init__(self):
-        self._chars = {"letters": string.ascii_letters,
-                       "digits": string.digits,
-                       "braces": '(){}[]',
-                       "punctuation": '.,:;',
-                       "quotes": '"\'',
-                       "dashes": '\\-|_/',
-                       "mathsym": '<*+!?=',
-                       "logograms": '#$%&@^`~'}
-
-        self._regex = {"letters": r'[a-zA-Z]+',
-                       "digits": r'[0-9]+',
-                       "braces": r'[(){}\[\]]+',
-                       "punctuation": r'[.,:;]+',
-                       "quotes": r'["\']+',
-                       "dashes": r'[\\-|_/]+',
-                       "mathsym": r'[<*+!?=]+',
-                       "logograms": r'[#$%&@^`~]+'}
+        self.keys = {"letters": 0,
+                     "digits": 1,
+                     "braces": 2,
+                     "punctuation": 3,
+                     "quotes": 4,
+                     "dashes": 5,
+                     "mathsym": 6,
+                     "logograms": 7}
+        self.chars = [string.ascii_letters,
+                      string.digits,
+                      '(){}[]',
+                      '.,:;',
+                      '"\'',
+                      '\\-|_/',
+                      '<*+!?=',
+                      '#$%&@^`~']
+        self.regex = [r'[a-zA-Z]+',
+                      r'[0-9]+',
+                      r'[(){}\[\]]+',
+                      r'[.,:;]+',
+                      r'["\']+',
+                      r'[\\-|_/]+',
+                      r'[<*+!?=]+',
+                      r'[#$%&@^`~]+']
 
     def get_chars(self, ident):
         """
         Returns string of characters, if they exist, else None."""
-        if ident in self._chars:
-            return self._chars[ident]
+        if ident in self.keys:
+            return self.chars[self.keys[ident]]
         return None
 
     def get_regex(self, ident):
         """
         Returns string of regex, if they exist, else None."""
-        if ident in self._regex:
-            return self._regex[ident]
+        if ident in self.keys:
+            return self.regex[self.keys[ident]]
         return None
 
-    def regex(self):
+    def keylist(self):
         """
-        Returns list of regex values."""
-        return list(self._regex.values())
+        Returns a list of keys."""
+        return list(self.keys.keys())
 
-    def chars(self):
-        """
-        Returns list of chars values."""
-        return list(self._chars.values())
 
-    def keys(self):
-        """
-        Returns list of keys."""
-        return list(self._chars.keys())
+
+
 
 
 CHARGROUPS_ = CharGroups()
@@ -1192,7 +1200,7 @@ def edit_entry(kpo, kp_entry):  # pylint: disable=too-many-return-statements, to
         else:
             passwd_sets = get_passwd_settings()
             if CONFIG_["ROFI"]:
-                for key in CHARGROUPS_.keys():
+                for key in CHARGROUPS_.keylist():
                     passwd_sets[key] = key
             pw_choice = ''
             input_b = b"20\n"
@@ -1207,7 +1215,7 @@ def edit_entry(kpo, kp_entry):  # pylint: disable=too-many-return-statements, to
             passwd_sel = dmenu_select(len(passwd_sets), "Which password set to use?", inp=input_b)
             alphabet_list = []
             for p_set in passwd_sel.split("\n"):
-                if p_set in CHARGROUPS_.keys():
+                if p_set in CHARGROUPS_.keylist():
                     alphabet_list.append(p_set)
                 elif p_set in passwd_sets:
                     alphabet_list.extend(passwd_sets[p_set])

--- a/keepmenu
+++ b/keepmenu
@@ -54,7 +54,7 @@ def random_str():
 
 
 def gen_pass(length=20, alphabet_list=[]):
-    """Generate password (min 4 chars, 1 lower, 1 upper, 1 digit, 1 special char)
+    """Generate password (min 4 chars or list length, at least one used of each group)
 
     Args: length - int (default 20)
           use_digits - bool (default True)
@@ -63,8 +63,9 @@ def gen_pass(length=20, alphabet_list=[]):
     Returns: password - string
 
     """
-    length = length if length >= 4 else 4
-    alphabet = "".join(CHAR_TYPES[a] for a in alphabet_list)
+    default_length = len(alphabet_list) if len(alphabet_list) > 4 else 4
+    length = length if length >= default_length else default_length
+    alphabet = ''.join(CHAR_TYPES[a] for a in alphabet_list)
     if not alphabet:
         alphabet = ''.join(list(CHAR_TYPES.values()))
     while True:

--- a/keepmenu
+++ b/keepmenu
@@ -28,10 +28,19 @@ from pykeyboard import PyKeyboard
 from pymouse.x11 import X11Error
 from pykeepass import PyKeePass
 
+try:
+    # secrets only available python 3.6+
+    from secrets import choice
+except ImportError:
+    def choice(seq):
+        """Provide `choice` function call for pw generation
+
+        """
+        return random.SystemRandom().choice(seq)
+
 
 AUTH_FILE = expanduser("~/.cache/.keepmenu-auth")
 CONF_FILE = expanduser("~/.config/keepmenu/config.ini")
-CONFIG = {'ROFI': False, 'SETS': {}}
 
 
 def find_free_port():
@@ -55,32 +64,28 @@ def random_str():
     return ''.join(random.choice(letters) for i in range(15))
 
 
-def gen_passwd(length=20, alphabet_list=None):
-    """Generate password (min 4 chars, returns Error if less than given groups)
+def gen_passwd(chars, length=20):
+    """Generate password (min = # of distinct character sets picked)
 
-    Args: length - int (default 20)
-          alphabet_list - list of strings (default ["letters", "digits", "braces"])
+    Args: chars - Dict {preset_name_1: {char_set_1: string, char_set_2: string},
+                        preset_name_2: ....}
+          length - int (default 20)
 
-    Returns: password - string
+    Returns: password - string OR False
 
     """
-    if alphabet_list is None:
-        alphabet_list = CHARGROUPS.keylist()
-    length = max(4, length)
-    alphabet_list = set(alphabet_list).intersection(CHARGROUPS.keylist())
-    alphabet = ''.join(CHARGROUPS.get_chars(al) for al in alphabet_list)
-    if len(alphabet_list) > length:
-        return "Error: not all character sets used. Please edit config.ini"
-    if not alphabet:
-        alphabet = ''.join(list(CHARGROUPS.chars))
-    while True:
-        password = ''.join(random.SystemRandom().choice(alphabet) for i in range(length))
-        count = 0
-        for alpha in alphabet_list:
-            count += 1 if (re.search(CHARGROUPS.get_regex(alpha), password)) else 0
-        if count == len(alphabet_list):
-            break
-    return password
+    sets = set()
+    if chars:
+        sets = set(j for i in chars.values() for j in i.values())
+    if length < len(sets) or not chars:
+        return False
+    alphabet = "".join(set("".join(j for j in i.values()) for i in chars.values()))
+    # Ensure minimum of one char from each character set
+    password = "".join(choice(k) for k in sets)
+    password += "".join(choice(alphabet) for i in range(length - len(sets)))
+    tpw = list(password)
+    random.shuffle(tpw)
+    return "".join(tpw)
 
 
 def process_config():
@@ -151,10 +156,6 @@ def process_config():
                 dmenu_err("Ydotool not installed.\n"
                           "Please install or remove that option from config.ini")
                 sys.exit()
-    if CONF.has_section("password"):
-        CONFIG["SETS"] = get_passwd_settings()
-    else:
-        CONFIG["SETS"] = default_passwd_sets()
 
 
 def get_auth():
@@ -192,8 +193,7 @@ def dmenu_cmd(num_lines, prompt):
     dmenu_command = command[0]
     dmenu_args = command[1:]
     del args_dict["dmenu_command"]
-    CONFIG["ROFI"] = bool("rofi" in dmenu_command)
-    lines = "-i -dmenu -multi-select -lines" if CONFIG["ROFI"] else "-i -l"
+    lines = "-i -dmenu -multi-select -lines" if "rofi" in dmenu_command else "-i -l"
     if "l" in args_dict:
         lines = "{} {}".format(lines, min(num_lines, int(args_dict['l'])))
         del args_dict['l']
@@ -209,7 +209,7 @@ def dmenu_cmd(num_lines, prompt):
         if CONF.has_option('dmenu_passphrase', 'rofi_obscure'):
             rofi_obscure = CONF.getboolean('dmenu_passphrase', 'rofi_obscure')
             del args_dict["rofi_obscure"]
-        if rofi_obscure is True and CONFIG["ROFI"]:
+        if rofi_obscure is True and "rofi" in dmenu_command:
             dmenu_args.extend(["-password"])
     extras = (["-" + str(k), str(v)] for (k, v) in args_dict.items())
     dmenu = [dmenu_command, "-p", str(prompt)]
@@ -252,98 +252,41 @@ def dmenu_err(prompt):
     return dmenu_select(1, prompt)
 
 
-def default_passwd_sets():
+def get_password_chars():
+    """Get characters to use for password generation from defaults, config file
+    and user input.
+
+    Returns: Dict {preset_name_1: {char_set_1: string, char_set_2: string},
+                   preset_name_2: ....}
     """
-    Returns a default dict of password sets"""
+    chars = {"upper": string.ascii_uppercase,
+             "lower": string.ascii_lowercase,
+             "digits": string.digits,
+             "punctuation": string.punctuation}
     presets = {}
-    presets["letters+digits+punctuation"] = ["letters",
-                                             "digits",
-                                             "braces",
-                                             "punctuation",
-                                             "quotes",
-                                             "dashes",
-                                             "mathsym",
-                                             "logograms"]
-    presets["letters+digits"] = ["letters", "digits"]
-    presets["letters"] = ["letters"]
-    return presets
-
-
-def get_passwd_settings():
-    """
-    Read settings for password generation
-
-    Returns: dict - Name : list of preset strings
-    """
-    presets = {}
-    if CONF.has_section('password'):
-        args = CONF.items('password')
-        args_dict = dict(args)
-        for key, value in args_dict.items():
-            passwd_set = set()
-            for group in value.split():
-                group = group.strip()
-                if group in CHARGROUPS.keylist():
-                    passwd_set.add(group)
-                else:
-                    dmenu_err(f"Error: Unknown value in preset {key}")
-                    sys.exit()
-                presets[key] = list(passwd_set)
-    if not presets:
-        presets = default_passwd_sets()
-    return presets
-
-
-class CharGroups:
-    """
-    Class for using character groups throughout this module"""
-    def __init__(self):
-        self.keys = {"letters": 0,
-                     "digits": 1,
-                     "braces": 2,
-                     "punctuation": 3,
-                     "quotes": 4,
-                     "dashes": 5,
-                     "mathsym": 6,
-                     "logograms": 7}
-        self.chars = [string.ascii_letters,
-                      string.digits,
-                      '(){}[]',
-                      '.,:;',
-                      '"\'',
-                      '\\-|_/',
-                      '<*+!?=',
-                      '#$%&@^`~']
-        self.regex = [r'[a-zA-Z]+',
-                      r'[0-9]+',
-                      r'[(){}\[\]]+',
-                      r'[.,:;]+',
-                      r'["\']+',
-                      r'[\\-|_/]+',
-                      r'[<*+!?=]+',
-                      r'[#$%&@^`~]+']
-
-    def get_chars(self, ident):
-        """
-        Returns string of characters, if they exist, else None."""
-        if ident in self.keys:
-            return self.chars[self.keys[ident]]
-        return None
-
-    def get_regex(self, ident):
-        """
-        Returns string of regex, if they exist, else None."""
-        if ident in self.keys:
-            return self.regex[self.keys[ident]]
-        return None
-
-    def keylist(self):
-        """
-        Returns a list of keys."""
-        return list(self.keys.keys())
-
-
-CHARGROUPS = CharGroups()
+    presets["Letters+Digits+Punctuation"] = chars
+    presets["Letters+Digits"] = {k: chars[k] for k in ("upper", "lower", "digits")}
+    presets["Letters"] = {k: chars[k] for k in ("upper", "lower")}
+    presets["Digits"] = {k: chars[k] for k in ("digits",)}
+    if CONF.has_section('password_chars'):
+        pw_chars = dict(CONF.items('password_chars'))
+        chars.update(pw_chars)
+        for key, val in pw_chars.items():
+            presets[key.title()] = {k: chars[k] for k in (key,)}
+    if CONF.has_section('password_char_presets'):
+        if CONF.options('password_char_presets'):
+            presets = {}
+        for name, val in CONF.items('password_char_presets'):
+            try:
+                presets[name.title()] = {k: chars[k] for k in shlex.split(val)}
+            except KeyError:
+                print("Error: Unknown value in preset {}. Ignoring.".format(name))
+                continue
+    input_b = "\n".join(presets).encode(ENC)
+    char_sel = dmenu_select(len(presets),
+                            "Pick character set(s) to use:", inp=input_b)
+    # This dictionary return also handles Rofi multiple select
+    return {k: presets[k] for k in char_sel.split('\n')} if char_sel else False
 
 
 def get_database():
@@ -1191,10 +1134,6 @@ def edit_entry(kpo, kp_entry):  # pylint: disable=too-many-return-statements, to
         elif not pw_choice:
             return True
         else:
-            passwd_sets = get_passwd_settings()
-            if CONFIG["ROFI"]:
-                for key in CHARGROUPS.keylist():
-                    passwd_sets[key] = key
             pw_choice = ''
             input_b = b"20\n"
             length = dmenu_select(1, "Password Length?", inp=input_b)
@@ -1204,20 +1143,13 @@ def edit_entry(kpo, kp_entry):  # pylint: disable=too-many-return-statements, to
                 length = int(length)
             except ValueError:
                 length = 20
-            input_b = str.encode("\n".join(list(passwd_sets.keys())))
-            passwd_sel = dmenu_select(len(passwd_sets), "Which password set to use?", inp=input_b)
-            alphabet_list = []
-            for p_set in passwd_sel.split("\n"):
-                if p_set in CHARGROUPS.keylist():
-                    alphabet_list.append(p_set)
-                elif p_set in passwd_sets:
-                    alphabet_list.extend(passwd_sets[p_set])
-                else:
-                    pass
-            sel = gen_passwd(length, alphabet_list)
-            if sel.startswith("Error:"):
-                dmenu_err(sel)
-                sys.exit()
+            chars = get_password_chars()
+            if chars is False:
+                return True
+            sel = gen_passwd(chars, length)
+            if sel is False:
+                dmenu_err("Number of char groups desired is more than requested pw length")
+                return True
 
     if field == 'autotype_enabled':
         input_b = b"True\nFalse\n"

--- a/keepmenu
+++ b/keepmenu
@@ -279,11 +279,9 @@ def get_passwd_settings():
     if CONF.has_section('password'):
         args = CONF.items('password')
         args_dict = dict(args)
-
         for key, value in args_dict.items():
-            groups = value.split('+')
             passwd_set = set()
-            for group in groups:
+            for group in value.split():
                 group = group.strip()
                 if group in CHARGROUPS.keylist():
                     passwd_set.add(group)

--- a/keepmenu
+++ b/keepmenu
@@ -91,6 +91,7 @@ def process_config():
            DMENU_LEN, \
            ENV, \
            ENC, \
+           ROFI, \
            SEQUENCE
     # pragma pylint: enable=global-variable-undefined
     ENV = os.environ.copy()
@@ -184,7 +185,8 @@ def dmenu_cmd(num_lines, prompt):
     dmenu_command = command[0]
     dmenu_args = command[1:]
     del args_dict["dmenu_command"]
-    lines = "-i -dmenu -lines" if "rofi" in dmenu_command else "-i -l"
+    ROFI = True if "rofi" in dmenu_command else False
+    lines = "-i -dmenu -multi-select -lines" if ROFI else "-i -l"
     if "l" in args_dict:
         lines = "{} {}".format(lines, min(num_lines, int(args_dict['l'])))
         del args_dict['l']
@@ -200,7 +202,7 @@ def dmenu_cmd(num_lines, prompt):
         if CONF.has_option('dmenu_passphrase', 'rofi_obscure'):
             rofi_obscure = CONF.getboolean('dmenu_passphrase', 'rofi_obscure')
             del args_dict["rofi_obscure"]
-        if rofi_obscure is True and "rofi" in dmenu_command:
+        if rofi_obscure is True and ROFI:
             dmenu_args.extend(["-password"])
     extras = (["-" + str(k), str(v)] for (k, v) in args_dict.items())
     dmenu = [dmenu_command, "-p", str(prompt)]
@@ -1136,6 +1138,9 @@ def edit_entry(kpo, kp_entry):  # pylint: disable=too-many-return-statements, to
             return True
         else:
             passwd_sets = get_passwd_settings()
+            if ROFI:
+                for key in CHAR_TYPES.keys():
+                    passwd_sets[key] = key
             pw_choice = ''
             input_b = b"20\n"
             length = dmenu_select(1, "Password Length?", inp=input_b)
@@ -1147,7 +1152,16 @@ def edit_entry(kpo, kp_entry):  # pylint: disable=too-many-return-statements, to
                 length = 20
             input_b = str.encode("\n".join(list(passwd_sets.keys())))
             passwd_sel = dmenu_select(len(passwd_sets), "Which password set to use?", inp=input_b)
-            sel = gen_passwd(length, passwd_sets[passwd_sel])
+            selection = [p for p in passwd_sel.split("\n")]
+            alphabet_list = []
+            for p_set in selection:
+                if p_set in CHAR_TYPES.keys():
+                    alphabet_list.append(p_set)
+                elif p_set in passwd_sets:
+                    alphabet_list.extend(passwd_sets[p_set])
+                else:
+                    pass
+            sel = gen_passwd(length, alphabet_list)
             if not sel:
                 dmenu_err("Error during password generation. Check your config.ini")
                 sys.exit()

--- a/keepmenu
+++ b/keepmenu
@@ -53,7 +53,7 @@ def random_str():
     return ''.join(random.choice(letters) for i in range(15))
 
 
-def gen_passwd(length=20, use_digits=True, use_spec_chars=True):
+def gen_pass(length=20, alphabet_list=[]):
     """Generate password (min 4 chars, 1 lower, 1 upper, 1 digit, 1 special char)
 
     Args: length - int (default 20)
@@ -64,15 +64,14 @@ def gen_passwd(length=20, use_digits=True, use_spec_chars=True):
 
     """
     length = length if length >= 4 else 4
-    dig = string.digits if use_digits is True else ''
-    spec = string.punctuation if use_spec_chars is True else ''
-    alphabet = string.ascii_letters + dig + spec
+    # TODO Requires a check for empty input
+    alphabet = "".join(CHAR_TYPES[a] for a in alphabet_list)
     while True:
         password = ''.join(random.SystemRandom().choice(alphabet) for i in range(length))
-        if (any(c.islower() for c in password)
-                and any(c.isupper() for c in password)
-                and (any(c.isdigit() for c in password) if dig else True)
-                and (any(c in string.punctuation for c in password) if spec else True)):
+        count = 0
+        for a in alphabet_list:
+            count += 1 if (re.search(REGEX_TYPES[a],password)) else 0
+        if count == len(alphabet_list):
             break
     return password
 
@@ -240,6 +239,56 @@ def dmenu_err(prompt):
     """
     return dmenu_select(1, prompt)
 
+
+
+def get_pass_settings():
+    """
+    Read settings for password generation
+
+    Returns: (dict of presets)
+    """
+    presets = {}
+    if CONF.has_section('password'):
+        args = CONF.items('password')
+        args_dict = dict(args)
+
+        for key, value in args_dict.items():
+            groups = value.split('+')
+            pass_set = set()
+            for group in groups:
+                group = group.strip()
+                if group in CHAR_TYPES:
+                    pass_set.add(group)
+                else:
+                    dmenu_err(f"Error in password preset {key}")
+                presets[key] = pass_set
+    if not presets:
+        presets["letters+digits+punctuation"] = ["letters","digits","dashes"]
+        presets["letters+digits"] = ["letters","digits"]
+        presets["letters"] = ["letters"]
+    return presets
+
+CHAR_TYPES = {
+    "letters" : string.ascii_letters,
+    "digits" : string.digits,
+    "braces" : "(){}[]",
+    "punctuation" : ".,:;",
+    "quotes" : "\"'",
+    "dashes" : "\\-|_/",
+    "mathsym" : "<*+!?=",
+    "logograms" : "#$%&@^`~",
+}
+
+REGEX_TYPES = {
+    "letters" : "[a-zA-Z]+",
+    "digits" : "[0-9]+",
+    "braces" : "[(){}\[\]]+",
+    "punctuation" : "[.,:;]+",
+    "quotes" : "[\"']+",
+    "dashes" : "[\\-|_/]+",
+    "mathsym" : "[<*+!?=]+",
+    "logograms" : "[#$%&@^`~]+",
+}
 
 def get_database():
     """Read databases from config or ask for user input.
@@ -1083,6 +1132,7 @@ def edit_entry(kpo, kp_entry):  # pylint: disable=too-many-return-statements, to
         elif not pw_choice:
             return True
         else:
+            pass_sets = get_pass_settings()
             pw_choice = ''
             input_b = b"20\n"
             length = dmenu_select(1, "Password Length?", inp=input_b)
@@ -1092,16 +1142,10 @@ def edit_entry(kpo, kp_entry):  # pylint: disable=too-many-return-statements, to
                 length = int(length)
             except ValueError:
                 length = 20
-            input_b = b"True\nFalse\n"
-            digits = dmenu_select(2, "Use digits? True/False", inp=input_b)
-            if not digits:
-                return True
-            digits = False if digits == 'False' else True
-            spec = dmenu_select(2, "Use special characters? True/False", inp=input_b)
-            if not spec:
-                return True
-            spec = False if spec == 'False' else True
-            sel = gen_passwd(length, digits, spec)
+            input_b = str.encode("\n".join(list(pass_sets.keys())))
+            pass_sel = dmenu_select(len(pass_sets), "Which password set to use?", inp=input_b)
+            sel = gen_pass(length, pass_sets[pass_sel])
+
     if field == 'autotype_enabled':
         input_b = b"True\nFalse\n"
         at_enab = dmenu_select(2, "Autotype Enabled? True/False", inp=input_b)

--- a/keepmenu
+++ b/keepmenu
@@ -54,7 +54,7 @@ def random_str():
 
 
 def gen_passwd(length=20, alphabet_list=["letters", "digits", "braces"]):
-    """Generate password (min 4 chars or list length, at least one used of each group)
+    """Generate password (min 4 chars, returns Error if less than given groups)
 
     Args: length - int (default 20)
           alphabet_list - list of strings (default ["letters", "digits", "braces"])
@@ -62,11 +62,14 @@ def gen_passwd(length=20, alphabet_list=["letters", "digits", "braces"]):
     Returns: password - string
 
     """
-    length = max(4, len(alphabet_list))
+    length = max(4, length)
     if set(alphabet_list).difference(set(CHAR_TYPES.keys())):
         for s in set(alphabet_list).difference(set(CHAR_TYPES.keys())):
             alphabet_list.remove(s)
     alphabet = ''.join(CHAR_TYPES[a] for a in alphabet_list)
+    if len(alphabet_list) > length:
+        return "Error: not all character sets used. Please edit config.ini"
+
     if not alphabet:
         alphabet = ''.join(list(CHAR_TYPES.values()))
     while True:
@@ -1162,8 +1165,8 @@ def edit_entry(kpo, kp_entry):  # pylint: disable=too-many-return-statements, to
                 else:
                     pass
             sel = gen_passwd(length, alphabet_list)
-            if not sel:
-                dmenu_err("Error during password generation. Check your config.ini")
+            if sel.startswith("Error:"):
+                dmenu_err(sel)
                 sys.exit()
 
     if field == 'autotype_enabled':

--- a/keepmenu
+++ b/keepmenu
@@ -64,8 +64,9 @@ def gen_pass(length=20, alphabet_list=[]):
 
     """
     length = length if length >= 4 else 4
-    # TODO Requires a check for empty input
     alphabet = "".join(CHAR_TYPES[a] for a in alphabet_list)
+    if not alphabet:
+        alphabet = ''.join(list(CHAR_TYPES.values()))
     while True:
         password = ''.join(random.SystemRandom().choice(alphabet) for i in range(length))
         count = 0

--- a/keepmenu
+++ b/keepmenu
@@ -53,20 +53,19 @@ def random_str():
     return ''.join(random.choice(letters) for i in range(15))
 
 
-def gen_passwd(length=20, alphabet_list=[]):
+def gen_passwd(length=20, alphabet_list=["letters", "digits", "braces"]):
     """Generate password (min 4 chars or list length, at least one used of each group)
 
     Args: length - int (default 20)
-          use_digits - bool (default True)
-          use_spec_chars - bool (default True)
+          alphabet_list - list of strings (default ["letters", "digits", "braces"])
 
     Returns: password - string
 
     """
-    default_length = len(alphabet_list) if len(alphabet_list) > 4 else 4
-    length = length if length >= default_length else default_length
+    length = max(4, len(alphabet_list))
     if set(alphabet_list).difference(set(CHAR_TYPES.keys())):
-        return None
+        for s in set(alphabet_list).difference(set(CHAR_TYPES.keys())):
+            alphabet_list.remove(s)
     alphabet = ''.join(CHAR_TYPES[a] for a in alphabet_list)
     if not alphabet:
         alphabet = ''.join(list(CHAR_TYPES.values()))
@@ -249,7 +248,7 @@ def get_passwd_settings():
     """
     Read settings for password generation
 
-    Returns: (dict of presets)
+    Returns: dict - Name : list of preset strings
     """
     presets = {}
     if CONF.has_section('password'):

--- a/keepmenu
+++ b/keepmenu
@@ -65,6 +65,8 @@ def gen_passwd(length=20, alphabet_list=[]):
     """
     default_length = len(alphabet_list) if len(alphabet_list) > 4 else 4
     length = length if length >= default_length else default_length
+    if set(alphabet_list).difference(set(CHAR_TYPES.keys())):
+        return None
     alphabet = ''.join(CHAR_TYPES[a] for a in alphabet_list)
     if not alphabet:
         alphabet = ''.join(list(CHAR_TYPES.values()))

--- a/keepmenu
+++ b/keepmenu
@@ -32,6 +32,7 @@ from pykeepass import PyKeePass
 AUTH_FILE = expanduser("~/.cache/.keepmenu-auth")
 CONF_FILE = expanduser("~/.config/keepmenu/config.ini")
 
+
 def find_free_port():
     """Find random free port to use for BaseManager server
 
@@ -53,7 +54,7 @@ def random_str():
     return ''.join(random.choice(letters) for i in range(15))
 
 
-def gen_passwd(length=20, alphabet_list=["letters", "digits", "braces"]):
+def gen_passwd(length=20, alphabet_list=None):
     """Generate password (min 4 chars, returns Error if less than given groups)
 
     Args: length - int (default 20)
@@ -62,24 +63,29 @@ def gen_passwd(length=20, alphabet_list=["letters", "digits", "braces"]):
     Returns: password - string
 
     """
+    if alphabet_list is None:
+        alphabet_list = ["letters", "digits", "braces"]
     length = max(4, length)
-    if set(alphabet_list).difference(set(CHAR_TYPES.keys())):
-        for s in set(alphabet_list).difference(set(CHAR_TYPES.keys())):
-            alphabet_list.remove(s)
-    alphabet = ''.join(CHAR_TYPES[a] for a in alphabet_list)
+    if set(alphabet_list).difference(set(CHARGROUPS_.keys())):
+        for alpha_set in set(alphabet_list).difference(set(CHARGROUPS_.keys())):
+            alphabet_list.remove(alpha_set)
+    alphabet = ''.join(CHARGROUPS_.get_chars(al) for al in alphabet_list)
     if len(alphabet_list) > length:
         return "Error: not all character sets used. Please edit config.ini"
 
     if not alphabet:
-        alphabet = ''.join(list(CHAR_TYPES.values()))
+        alphabet = ''.join(list(CHARGROUPS_.chars()))
     while True:
         password = ''.join(random.SystemRandom().choice(alphabet) for i in range(length))
         count = 0
-        for a in alphabet_list:
-            count += 1 if (re.search(REGEX_TYPES[a],password)) else 0
+        for alpha in alphabet_list:
+            count += 1 if (re.search(CHARGROUPS_.get_regex(alpha), password)) else 0
         if count == len(alphabet_list):
             break
     return password
+
+
+CONFIG_ = {'ROFI': False}
 
 
 def process_config():
@@ -89,13 +95,12 @@ def process_config():
     """
     # pragma pylint: disable=global-variable-undefined
     global CACHE_PERIOD_MIN, \
-           CACHE_PERIOD_DEFAULT_MIN, \
-           CONF, \
-           DMENU_LEN, \
-           ENV, \
-           ENC, \
-           ROFI, \
-           SEQUENCE
+        CACHE_PERIOD_DEFAULT_MIN, \
+        CONF, \
+        DMENU_LEN, \
+        ENV, \
+        ENC, \
+        SEQUENCE
     # pragma pylint: enable=global-variable-undefined
     ENV = os.environ.copy()
     ENV['LC_ALL'] = 'C'
@@ -188,8 +193,8 @@ def dmenu_cmd(num_lines, prompt):
     dmenu_command = command[0]
     dmenu_args = command[1:]
     del args_dict["dmenu_command"]
-    ROFI = True if "rofi" in dmenu_command else False
-    lines = "-i -dmenu -multi-select -lines" if ROFI else "-i -l"
+    CONFIG_["ROFI"] = bool("rofi" in dmenu_command)
+    lines = "-i -dmenu -multi-select -lines" if CONFIG_["ROFI"] else "-i -l"
     if "l" in args_dict:
         lines = "{} {}".format(lines, min(num_lines, int(args_dict['l'])))
         del args_dict['l']
@@ -205,7 +210,7 @@ def dmenu_cmd(num_lines, prompt):
         if CONF.has_option('dmenu_passphrase', 'rofi_obscure'):
             rofi_obscure = CONF.getboolean('dmenu_passphrase', 'rofi_obscure')
             del args_dict["rofi_obscure"]
-        if rofi_obscure is True and ROFI:
+        if rofi_obscure is True and CONFIG_["ROFI"]:
             dmenu_args.extend(["-password"])
     extras = (["-" + str(k), str(v)] for (k, v) in args_dict.items())
     dmenu = [dmenu_command, "-p", str(prompt)]
@@ -265,38 +270,80 @@ def get_passwd_settings():
             passwd_set = set()
             for group in groups:
                 group = group.strip()
-                if group in CHAR_TYPES:
+                if group in CHARGROUPS_.keys():
                     passwd_set.add(group)
                 else:
+                    # TODO This should end keepmenu
                     dmenu_err(f"Error in password preset {key}")
-                presets[key] = passwd_set
+                presets[key] = list(passwd_set)
     if not presets:
-        presets["letters+digits+punctuation"] = ["letters","digits","braces","punctuation","quotes","dashes","mathsym","logograms"]
-        presets["letters+digits"] = ["letters","digits"]
+        presets["letters+digits+punctuation"] = ["letters",
+                                                 "digits",
+                                                 "braces",
+                                                 "punctuation",
+                                                 "quotes",
+                                                 "dashes",
+                                                 "mathsym",
+                                                 "logograms"]
+        presets["letters+digits"] = ["letters", "digits"]
         presets["letters"] = ["letters"]
     return presets
 
-CHAR_TYPES = {
-    "letters" : string.ascii_letters,
-    "digits" : string.digits,
-    "braces" : '(){}[]',
-    "punctuation" : '.,:;',
-    "quotes" : '"\'',
-    "dashes" : '\\-|_/',
-    "mathsym" : '<*+!?=',
-    "logograms" : '#$%&@^`~',
-}
 
-REGEX_TYPES = {
-    "letters" : r'[a-zA-Z]+',
-    "digits" : r'[0-9]+',
-    "braces" : r'[(){}\[\]]+',
-    "punctuation" : r'[.,:;]+',
-    "quotes" : r'["\']+',
-    "dashes" : r'[\\-|_/]+',
-    "mathsym" : r'[<*+!?=]+',
-    "logograms" : r'[#$%&@^`~]+',
-}
+class CharGroups:
+    """
+    Class for using character groups throughout this module"""
+    def __init__(self):
+        self._chars = {"letters": string.ascii_letters,
+                       "digits": string.digits,
+                       "braces": '(){}[]',
+                       "punctuation": '.,:;',
+                       "quotes": '"\'',
+                       "dashes": '\\-|_/',
+                       "mathsym": '<*+!?=',
+                       "logograms": '#$%&@^`~'}
+
+        self._regex = {"letters": r'[a-zA-Z]+',
+                       "digits": r'[0-9]+',
+                       "braces": r'[(){}\[\]]+',
+                       "punctuation": r'[.,:;]+',
+                       "quotes": r'["\']+',
+                       "dashes": r'[\\-|_/]+',
+                       "mathsym": r'[<*+!?=]+',
+                       "logograms": r'[#$%&@^`~]+'}
+
+    def get_chars(self, ident):
+        """
+        Returns string of characters, if they exist, else None."""
+        if ident in self._chars:
+            return self._chars[ident]
+        return None
+
+    def get_regex(self, ident):
+        """
+        Returns string of regex, if they exist, else None."""
+        if ident in self._regex:
+            return self._regex[ident]
+        return None
+
+    def regex(self):
+        """
+        Returns list of regex values."""
+        return list(self._regex.values())
+
+    def chars(self):
+        """
+        Returns list of chars values."""
+        return list(self._chars.values())
+
+    def keys(self):
+        """
+        Returns list of keys."""
+        return list(self._chars.keys())
+
+
+CHARGROUPS_ = CharGroups()
+
 
 def get_database():
     """Read databases from config or ask for user input.
@@ -413,8 +460,8 @@ def get_passphrase():
         password = ""
         out = Popen(pinentry,
                     stdout=PIPE,
-                    stdin=PIPE).communicate( \
-                            input=b'setdesc Enter database password\ngetpin\n')[0]
+                    stdin=PIPE).communicate(
+                        input=b'setdesc Enter database password\ngetpin\n')[0]
         if out:
             res = out.decode(ENC).split("\n")[2]
             if res.startswith("D "):
@@ -449,7 +496,7 @@ def tokenize_autotype(autotype):
 
         if autotype[opening_idx] in "+^%~@":
             yield autotype[opening_idx], True
-            autotype = autotype[opening_idx+1:]
+            autotype = autotype[opening_idx + 1:]
             continue
 
         closing_idx = autotype.find('}')
@@ -460,12 +507,11 @@ def tokenize_autotype(autotype):
         if closing_idx == opening_idx + 1 and closing_idx + 1 < len(autotype) \
                 and autotype[closing_idx + 1] == '}':
             yield "{}}", True
-            autotype = autotype[closing_idx+2:]
+            autotype = autotype[closing_idx + 2:]
             continue
-        else:
-            yield autotype[opening_idx:closing_idx+1], True
+        yield autotype[opening_idx:closing_idx + 1], True
+        autotype = autotype[closing_idx + 1:]
 
-        autotype = autotype[closing_idx+1:]
 
 def token_command(token):
     """When token denotes a special command, this function provides a callable
@@ -475,7 +521,7 @@ def token_command(token):
     cmd = None
 
     def _check_delay():
-        match = re.match('{DELAY (\d+)}', token)
+        match = re.match(r'{DELAY (\d+)}', token)
         if match:
             delay = match.group(1)
             nonlocal cmd
@@ -486,6 +532,7 @@ def token_command(token):
     if _check_delay():  # {DELAY x}
         return cmd
     return None
+
 
 def type_entry(entry):
     """Pick which library to use to type strings
@@ -760,6 +807,7 @@ def type_entry_xdotool(entry, tokens):
         else:
             call(['xdotool', 'type', token])
 
+
 YDOTOOL_AUTOTYPE_TOKENS = {
     "{TAB}"       : ['key', 'TAB'],
     "{ENTER}"     : ['key', 'ENTER'],
@@ -783,9 +831,9 @@ YDOTOOL_AUTOTYPE_TOKENS = {
     "{BREAK}"     : ['key', 'BREAK'],
     "{CAPSLOCK}"  : ['key', 'CAPSLOCK'],
     "{ESC}"       : ['key', 'ESC'],
-    #"{WIN}"       : ['key', 'Super'],
-    #"{LWIN}"      : ['key', 'Super_L'],
-    #"{RWIN}"      : ['key', 'Super_R'],
+    # "{WIN}"       : ['key', 'Super'],
+    # "{LWIN}"      : ['key', 'Super_L'],
+    # "{RWIN}"      : ['key', 'Super_R'],
     # "{APPS}"      : ['key', ''],
     # "{HELP}"      : ['key', ''],
     "{NUMLOCK}"   : ['key', 'NUMLOCK'],
@@ -824,8 +872,9 @@ YDOTOOL_AUTOTYPE_TOKENS = {
     "+"           : ['key', 'LEFTSHIFT'],
     "^"           : ['Key', 'LEFTCTRL'],
     "%"           : ['key', 'LEFTALT'],
-    #"@"           : ['key', 'Super']
+    # "@"           : ['key', 'Super']
 }
+
 
 def type_entry_ydotool(entry, tokens):
     """Auto-type entry entry using ydotool
@@ -858,6 +907,7 @@ def type_entry_ydotool(entry, tokens):
                 return
         else:
             call(['ydotool', 'type', token])
+
 
 def type_text(data):
     """Type the given text data
@@ -941,7 +991,7 @@ def manage_groups(kpo):
     group = False
     while edit is True:
         input_b = b"\n".join(i.encode(ENC) for i in options) + b"\n\n" + \
-                b"\n".join(i.path.encode(ENC) for i in kpo.groups)
+            b"\n".join(i.path.encode(ENC) for i in kpo.groups)
         sel = dmenu_select(len(options) + len(kpo.groups) + 1, "Groups", inp=input_b)
         if not sel:
             edit = False
@@ -1141,8 +1191,8 @@ def edit_entry(kpo, kp_entry):  # pylint: disable=too-many-return-statements, to
             return True
         else:
             passwd_sets = get_passwd_settings()
-            if ROFI:
-                for key in CHAR_TYPES.keys():
+            if CONFIG_["ROFI"]:
+                for key in CHARGROUPS_.keys():
                     passwd_sets[key] = key
             pw_choice = ''
             input_b = b"20\n"
@@ -1155,10 +1205,9 @@ def edit_entry(kpo, kp_entry):  # pylint: disable=too-many-return-statements, to
                 length = 20
             input_b = str.encode("\n".join(list(passwd_sets.keys())))
             passwd_sel = dmenu_select(len(passwd_sets), "Which password set to use?", inp=input_b)
-            selection = [p for p in passwd_sel.split("\n")]
             alphabet_list = []
-            for p_set in selection:
-                if p_set in CHAR_TYPES.keys():
+            for p_set in passwd_sel.split("\n"):
+                if p_set in CHARGROUPS_.keys():
                     alphabet_list.append(p_set)
                 elif p_set in passwd_sets:
                     alphabet_list.extend(passwd_sets[p_set])
@@ -1174,7 +1223,7 @@ def edit_entry(kpo, kp_entry):  # pylint: disable=too-many-return-statements, to
         at_enab = dmenu_select(2, "Autotype Enabled? True/False", inp=input_b)
         if not at_enab:
             return True
-        sel = False if at_enab == 'False' else True
+        sel = not at_enab == 'False'
     if (field not in ('password', 'notes', 'path', 'autotype_enabled')) or pw_choice:
         sel = dmenu_select(1, "{}".format(field.capitalize()), inp=edit_b)
         if not sel:

--- a/keepmenu
+++ b/keepmenu
@@ -31,6 +31,7 @@ from pykeepass import PyKeePass
 
 AUTH_FILE = expanduser("~/.cache/.keepmenu-auth")
 CONF_FILE = expanduser("~/.config/keepmenu/config.ini")
+CONFIG = {'ROFI': False, 'SETS': {}}
 
 
 def find_free_port():
@@ -64,25 +65,22 @@ def gen_passwd(length=20, alphabet_list=None):
 
     """
     if alphabet_list is None:
-        alphabet_list = CHARGROUPS_.keylist()
+        alphabet_list = CHARGROUPS.keylist()
     length = max(4, length)
-    alphabet_list = set(alphabet_list).intersection(CHARGROUPS_.keylist())
-    alphabet = ''.join(CHARGROUPS_.get_chars(al) for al in alphabet_list)
+    alphabet_list = set(alphabet_list).intersection(CHARGROUPS.keylist())
+    alphabet = ''.join(CHARGROUPS.get_chars(al) for al in alphabet_list)
     if len(alphabet_list) > length:
         return "Error: not all character sets used. Please edit config.ini"
     if not alphabet:
-        alphabet = ''.join(list(CHARGROUPS_.chars))
+        alphabet = ''.join(list(CHARGROUPS.chars))
     while True:
         password = ''.join(random.SystemRandom().choice(alphabet) for i in range(length))
         count = 0
         for alpha in alphabet_list:
-            count += 1 if (re.search(CHARGROUPS_.get_regex(alpha), password)) else 0
+            count += 1 if (re.search(CHARGROUPS.get_regex(alpha), password)) else 0
         if count == len(alphabet_list):
             break
     return password
-
-
-CONFIG_ = {'ROFI': False, 'SETS': {}}
 
 
 def process_config():
@@ -154,9 +152,9 @@ def process_config():
                           "Please install or remove that option from config.ini")
                 sys.exit()
     if CONF.has_section("password"):
-        CONFIG_["SETS"] = get_passwd_settings()
+        CONFIG["SETS"] = get_passwd_settings()
     else:
-        CONFIG_["SETS"] = default_passwd_sets()
+        CONFIG["SETS"] = default_passwd_sets()
 
 
 def get_auth():
@@ -194,8 +192,8 @@ def dmenu_cmd(num_lines, prompt):
     dmenu_command = command[0]
     dmenu_args = command[1:]
     del args_dict["dmenu_command"]
-    CONFIG_["ROFI"] = bool("rofi" in dmenu_command)
-    lines = "-i -dmenu -multi-select -lines" if CONFIG_["ROFI"] else "-i -l"
+    CONFIG["ROFI"] = bool("rofi" in dmenu_command)
+    lines = "-i -dmenu -multi-select -lines" if CONFIG["ROFI"] else "-i -l"
     if "l" in args_dict:
         lines = "{} {}".format(lines, min(num_lines, int(args_dict['l'])))
         del args_dict['l']
@@ -211,7 +209,7 @@ def dmenu_cmd(num_lines, prompt):
         if CONF.has_option('dmenu_passphrase', 'rofi_obscure'):
             rofi_obscure = CONF.getboolean('dmenu_passphrase', 'rofi_obscure')
             del args_dict["rofi_obscure"]
-        if rofi_obscure is True and CONFIG_["ROFI"]:
+        if rofi_obscure is True and CONFIG["ROFI"]:
             dmenu_args.extend(["-password"])
     extras = (["-" + str(k), str(v)] for (k, v) in args_dict.items())
     dmenu = [dmenu_command, "-p", str(prompt)]
@@ -270,6 +268,7 @@ def default_passwd_sets():
     presets["letters"] = ["letters"]
     return presets
 
+
 def get_passwd_settings():
     """
     Read settings for password generation
@@ -286,7 +285,7 @@ def get_passwd_settings():
             passwd_set = set()
             for group in groups:
                 group = group.strip()
-                if group in CHARGROUPS_.keylist():
+                if group in CHARGROUPS.keylist():
                     passwd_set.add(group)
                 else:
                     dmenu_err(f"Error: Unknown value in preset {key}")
@@ -346,11 +345,7 @@ class CharGroups:
         return list(self.keys.keys())
 
 
-
-
-
-
-CHARGROUPS_ = CharGroups()
+CHARGROUPS = CharGroups()
 
 
 def get_database():
@@ -1199,8 +1194,8 @@ def edit_entry(kpo, kp_entry):  # pylint: disable=too-many-return-statements, to
             return True
         else:
             passwd_sets = get_passwd_settings()
-            if CONFIG_["ROFI"]:
-                for key in CHARGROUPS_.keylist():
+            if CONFIG["ROFI"]:
+                for key in CHARGROUPS.keylist():
                     passwd_sets[key] = key
             pw_choice = ''
             input_b = b"20\n"
@@ -1215,7 +1210,7 @@ def edit_entry(kpo, kp_entry):  # pylint: disable=too-many-return-statements, to
             passwd_sel = dmenu_select(len(passwd_sets), "Which password set to use?", inp=input_b)
             alphabet_list = []
             for p_set in passwd_sel.split("\n"):
-                if p_set in CHARGROUPS_.keylist():
+                if p_set in CHARGROUPS.keylist():
                     alphabet_list.append(p_set)
                 elif p_set in passwd_sets:
                     alphabet_list.extend(passwd_sets[p_set])

--- a/keepmenu
+++ b/keepmenu
@@ -263,7 +263,7 @@ def get_pass_settings():
                     dmenu_err(f"Error in password preset {key}")
                 presets[key] = pass_set
     if not presets:
-        presets["letters+digits+punctuation"] = ["letters","digits","dashes"]
+        presets["letters+digits+punctuation"] = ["letters","digits","braces","punctuation","quotes","dashes","mathsym","logograms"]
         presets["letters+digits"] = ["letters","digits"]
         presets["letters"] = ["letters"]
     return presets

--- a/keepmenu
+++ b/keepmenu
@@ -53,7 +53,7 @@ def random_str():
     return ''.join(random.choice(letters) for i in range(15))
 
 
-def gen_pass(length=20, alphabet_list=[]):
+def gen_passwd(length=20, alphabet_list=[]):
     """Generate password (min 4 chars or list length, at least one used of each group)
 
     Args: length - int (default 20)
@@ -243,7 +243,7 @@ def dmenu_err(prompt):
 
 
 
-def get_pass_settings():
+def get_passwd_settings():
     """
     Read settings for password generation
 
@@ -256,14 +256,14 @@ def get_pass_settings():
 
         for key, value in args_dict.items():
             groups = value.split('+')
-            pass_set = set()
+            passwd_set = set()
             for group in groups:
                 group = group.strip()
                 if group in CHAR_TYPES:
-                    pass_set.add(group)
+                    passwd_set.add(group)
                 else:
                     dmenu_err(f"Error in password preset {key}")
-                presets[key] = pass_set
+                presets[key] = passwd_set
     if not presets:
         presets["letters+digits+punctuation"] = ["letters","digits","braces","punctuation","quotes","dashes","mathsym","logograms"]
         presets["letters+digits"] = ["letters","digits"]
@@ -1134,7 +1134,7 @@ def edit_entry(kpo, kp_entry):  # pylint: disable=too-many-return-statements, to
         elif not pw_choice:
             return True
         else:
-            pass_sets = get_pass_settings()
+            passwd_sets = get_passwd_settings()
             pw_choice = ''
             input_b = b"20\n"
             length = dmenu_select(1, "Password Length?", inp=input_b)
@@ -1144,9 +1144,12 @@ def edit_entry(kpo, kp_entry):  # pylint: disable=too-many-return-statements, to
                 length = int(length)
             except ValueError:
                 length = 20
-            input_b = str.encode("\n".join(list(pass_sets.keys())))
-            pass_sel = dmenu_select(len(pass_sets), "Which password set to use?", inp=input_b)
-            sel = gen_pass(length, pass_sets[pass_sel])
+            input_b = str.encode("\n".join(list(passwd_sets.keys())))
+            passwd_sel = dmenu_select(len(passwd_sets), "Which password set to use?", inp=input_b)
+            sel = gen_passwd(length, passwd_sets[passwd_sel])
+            if not sel:
+                dmenu_err("Error during password generation. Check your config.ini")
+                sys.exit()
 
     if field == 'autotype_enabled':
         input_b = b"True\nFalse\n"

--- a/keepmenu.1
+++ b/keepmenu.1
@@ -122,7 +122,18 @@ your window manager or desktop environment initialization. For example:
 .RS
 \fIexec setxkbmap de\fP in ~/.config/i3/config.
 .RE
+
+For customizing password generation uncomment the password section und add
+entries to your liking. The key in front will be shown in dmenu/rofi while the
+values will compose the used character set for the password.
+Valid values in no particular order, combined with the +, are the following:
+.RS
+    letters digits braces punctuation quotes dashes mathsym logograms
 .RE
+For example, setting \ffoo=letters+braces\f creates a preset which would
+generate a password from letters a-z and A-Z as well as {}[]().
+.RE
+
 
 \fB3.\fR If using Rofi, you can try some of the command line options in
 config.ini or set them using the \fIdmenu_command\fP setting, but I haven\(aqt

--- a/keepmenu.1
+++ b/keepmenu.1
@@ -48,14 +48,20 @@ entries\(aq views.
 entered passphrase for \fIpw_cache_period_min\fP minutes after the last
 activity.
 
-\fB14.\fR Optional Pinentry support for secure passphrase entry.
+\fB14. \fR Configure the characters and groups of characters used during
+password generation in the config file (see config.ini.example for
+instructions). Multiple character sets can be selected on the fly when using
+Rofi.
+
+\fB15.\fR Optional Pinentry support for secure passphrase entry.
 
 .SH LICENSE
 Copyright © 2020 Scott Hansen <firecat4153@gmail.com>.  Keepmenu is released under the terms of the GPLv3 license.
 
 
 .SH REQUIREMENTS
-\fB1.\fR Python 3.4+
+\fB1.\fR Python 3.4+. *Note* Python 3.6+ uses the \fIsecrets\fP module for password
+generation to improve security.
 
 \fB2.\fR \fI\%Pykeepass\fP and \fI\%PyUserInput\fP\&. Install via pip or your
 distribution\(aqs package manager, if available.
@@ -123,17 +129,18 @@ your window manager or desktop environment initialization. For example:
 \fIexec setxkbmap de\fP in ~/.config/i3/config.
 .RE
 
-For customizing password generation uncomment the password section und add
-entries to your liking. The key in front will be shown in dmenu/rofi while the
-values will compose the used character set for the password.
-Valid values in no particular order, combined with a whitespace, are the following:
-.RS
-    letters digits braces punctuation quotes dashes mathsym logograms
-.RE
-For example, setting \ffoo=letters+braces\f creates a preset which would
-generate a password from letters a-z and A-Z as well as {}[]().
-.RE
+New sets of characters can be set in config.ini in the \fI[password_chars]\fP
+section. A new preset for each custom set will be listed in addition to the
+default presets. If you redefine one of the default sets (upper, lower, digits,
+punctuation), it will replace the default values.
 
+New preset groups of character sets can be defined in config.ini in the
+\fI[password_char_presets]\fP section. You can set any combination of default
+and custom character sets. A minimum of one character from each distinct set
+will be used when generating a new password. If any custom presets are defined,
+the default presets will not be displayed unless they are uncommented.
+
+.RE
 
 \fB3.\fR If using Rofi, you can try some of the command line options in
 config.ini or set them using the \fIdmenu_command\fP setting, but I haven\(aqt

--- a/keepmenu.1
+++ b/keepmenu.1
@@ -126,7 +126,7 @@ your window manager or desktop environment initialization. For example:
 For customizing password generation uncomment the password section und add
 entries to your liking. The key in front will be shown in dmenu/rofi while the
 values will compose the used character set for the password.
-Valid values in no particular order, combined with the +, are the following:
+Valid values in no particular order, combined with a whitespace, are the following:
 .RS
     letters digits braces punctuation quotes dashes mathsym logograms
 .RE

--- a/tests/keepmenu-config.ini
+++ b/tests/keepmenu-config.ini
@@ -22,3 +22,8 @@ gui_editor = gvim -f
 type_library = xdotool
 hide_groups = Recycle Bin
               Test
+[password_chars]
+punc min = !@#$%%
+
+[password_char_presets]
+Minimal Punc = upper lower digits "punc min"

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -113,7 +113,6 @@ class TestFunctions(unittest.TestCase):
         self.assertFalse(pword.isdisjoint(set('!@#$%')))
         self.assertTrue(pword.isdisjoint(set('   ')))
         pword = KM.gen_passwd(chars, 3)
-        self.assertFalse(KM.gen_passwd({}))
         pword = KM.gen_passwd(chars, 5)
         self.assertEqual(len(pword), 5)
         chars = {'Min Punc': {'min punc': '!@#$%',

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -100,7 +100,7 @@ class TestFunctions(unittest.TestCase):
             else:
                 self.assertTrue(len(pword) == args[0] or len(pword) == 4)
                 for arg in args[1]:
-                    if arg in KM.CHARGROUPS_.regex:
+                    if arg in KM.CHARGROUPS.regex:
                         self.assertTrue(re.search(KM.CHARGROUPS.get_regex(arg), pword))
 
     def test_conf(self):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -95,13 +95,12 @@ class TestFunctions(unittest.TestCase):
             pword = KM.gen_passwd(*args)
             if not args:
                 args = (20, [])  ## Defaults for gen_passwd
-            if set(args[1]).difference(set(KM.CHARGROUPS_.keys())) or len(args[1]) > max(4, args[0]):
+            if len(args[1]) > max(4, args[0]):
                 self.assertTrue(pword.startswith("Error:"))
             else:
-                print(f"length: {args[0]} list: {args[1]} pword: {pword}")
                 self.assertTrue(len(pword) == args[0] or len(pword) == 4)
                 for arg in args[1]:
-                    if arg in KM.CHARGROUPS_.regex():
+                    if arg in KM.CHARGROUPS_.regex:
                         self.assertTrue(re.search(KM.CHARGROUPS.get_regex(arg), pword))
 
     def test_conf(self):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -85,23 +85,24 @@ class TestFunctions(unittest.TestCase):
         """
         # args = (length, [list of identifiers])
         values = [(0, ["letters"]),
-                  (2, ["letters","digits","braces","punctuation","dashes"]),
-                  (10, ["letters","digits","braces","punctuation"]),
-                  (20, ["mathsym","digits","brace","punctuation"]),
-                  (1000, ["logograms","digits","braces","punctuation"]),
-                  (50, ["letters","digits","braces","dots"]),
+                  (2, ["letters", "digits", "braces", "punctuation", "dashes"]),
+                  (10, ["letters", "digits", "braces", "punctuation"]),
+                  (20, ["mathsym", "digits", "brace", "punctuation"]),
+                  (1000, ["logograms", "digits", "braces", "punctuation"]),
+                  (50, ["letters", "digits", "braces", "dots"]),
                   ()]
         for args in values:
             pword = KM.gen_passwd(*args)
             if not args:
                 args = (20, [])  ## Defaults for gen_passwd
-            if set(args[1]).difference(set(KM.REGEX_TYPES.keys())):
-                self.assertTrue(pword is None)
+            if set(args[1]).difference(set(KM.CHARGROUPS_.keys())) or len(args[1]) > max(4, args[0]):
+                self.assertTrue(pword.startswith("Error:"))
             else:
-                self.assertTrue(len(pword) == args[0] or len(pword) == 4 or len(pword) == len(args[1]))
-                for a in args[1]:
-                    if a in KM.REGEX_TYPES:
-                        self.assertTrue(re.search(KM.REGEX_TYPES[a],pword))
+                print(f"length: {args[0]} list: {args[1]} pword: {pword}")
+                self.assertTrue(len(pword) == args[0] or len(pword) == 4)
+                for arg in args[1]:
+                    if arg in KM.CHARGROUPS_.regex():
+                        self.assertTrue(re.search(KM.CHARGROUPS.get_regex(arg), pword))
 
     def test_conf(self):
         """Test generating config file when none exists

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -136,12 +136,12 @@ class TestFunctions(unittest.TestCase):
         copyfile("tests/keepmenu-config.ini", KM.CONF_FILE)
         KM.process_config()
         if sys.version_info.major < 3:
-            res = ['/usr/bin/rofi', '-i', '-dmenu', '-lines', '10', '-p',
+            res = ['/usr/bin/rofi', '-i', '-dmenu', '-multi-select', '-lines', '10', '-p',
                    u'Passphrase', '-password', u'-b', u'-nb', u'#222222',
                    u'-nf', u'#222222', u'-sb', u'#123456', u'-fn',
                    u'Inconsolata-12']
         else:
-            res = ["/usr/bin/rofi", "-i", "-dmenu", "-lines", "10", "-p", "Passphrase",
+            res = ["/usr/bin/rofi", "-i", "-dmenu", "-multi-select", "-lines", "10", "-p", "Passphrase",
                    "-password", "-fn", "Inconsolata-12", "-nb", "#222222", "-nf", "#222222",
                    "-sb", "#123456", "-b"]
         self.assertTrue(KM.dmenu_cmd(20, "Passphrase") == res)


### PR DESCRIPTION
Implements a configurable password generator which uses groups of characters selectable in the config file. Current values include the following:
```
    "letters" : string.ascii_letters,
    "digits" : string.digits,
    "braces" : "(){}[]",
    "punctuation" : ".,:;",
    "quotes" : "\"'",
    "dashes" : "\\-|_/",
    "mathsym" : "<*+!?=",
    "logograms" : "#$%&@^`~",
```
These can be set in the config ini like this:
```
[password]
# valid values are letters, digits, braces, punctuation, quotes, dashes, mathsym, logograms
# combined with a plus sign
set_1=letters+letters+digits+dashes
foo=letters+digits
bar=letters+digits+braces+punctuation+quotes+dashes+mathsym+logograms
```

### Some notes

1. ~~Tests are currently failing as these have not been updated yet.~~
1. ~~The global `REGEX_TYPES` might be unnecessary.~~ They are required for testing purposes.
1. `get_pass_settings()` is only checked at runtime and not at the start. Thus, eventual errors in the config regarding the presets are only detected during password generation. Should this be moved to `process_config():`?

Im just starting to learn python so any help and suggestions are welcome!

Closes #51  