### PR TITLE
Fix viewing entries with filtered groups

### DIFF
--- a/keepmenu
+++ b/keepmenu
@@ -1351,11 +1351,13 @@ class DmenuRunner(Process):
 
         """
         options = []
-        sel = view_all_entries(options, [i for i in self.kpo.entries if not
-                                         any(j in i.path.rstrip(i.title) for
-                                             j in hid_groups)])
+        filtered_entries = [
+            i for i in self.kpo.entries if not
+            any(j in i.path.rstrip(i.title) for j in hid_groups)
+        ]
+        sel = view_all_entries(options, filtered_entries)
         try:
-            entry = self.kpo.entries[int(sel.split('-', 1)[0])]
+            entry = filtered_entries[int(sel.split('-', 1)[0])]
         except (ValueError, TypeError):
             return
         text = view_entry(entry)

--- a/keepmenu
+++ b/keepmenu
@@ -1322,9 +1322,13 @@ class DmenuRunner(Process):
                           [j.name for j in self.kpo.groups]]
         else:
             hid_groups = []
-        sel = view_all_entries(options, [i for i in self.kpo.entries if not
-                                         any(j in i.path.rstrip(i.title) for
-                                             j in hid_groups)])
+
+        filtered_entries = [
+            i for i in self.kpo.entries if not
+            any(j in i.path.rstrip(i.title) for j in hid_groups)
+        ]
+
+        sel = view_all_entries(options, filtered_entries)
         if not sel:
             return
         if sel == options[0]:
@@ -1341,7 +1345,7 @@ class DmenuRunner(Process):
             self.menu_kill_daemon()
         else:
             try:
-                entry = self.kpo.entries[int(sel.split('-', 1)[0])]
+                entry = filtered_entries[int(sel.split('-', 1)[0])]
             except (ValueError, TypeError):
                 return
             type_entry(entry)


### PR DESCRIPTION
Without this change, we present a list of filtered entries to the
user (and let them pick an index from that list), but then use that
index based on the unfiltered list.

This causes a totally different entry to be shown instead of the one the
user selected.