### PR TITLE
Fix UnboundLocalError with corrupted auth file

### DIFF
--- a/keepmenu
+++ b/keepmenu
@@ -177,6 +177,7 @@ def get_auth():
         os.remove(AUTH_FILE)
         print("Cache file was corrupted. Stopping all instances. Please try again")
         call(["pkill", "keepmenu"])  # Kill all prior instances as well
+        return
     return int(port), authkey
 
 


### PR DESCRIPTION
Without a 'return' there, keepmenu fails with:

    Cache file was corrupted. Stopping all instances. Please try again
    Traceback (most recent call last):
      File "./keepmenu", line 1464, in <module>
        MANAGER = client()
      File "./keepmenu", line 1238, in client
        port, auth = get_auth()
      File "./keepmenu", line 181, in get_auth
        return int(port), authkey
    UnboundLocalError: local variable 'port' referenced before assignment