### PR TITLE
Add menu item to show previous entry

### DIFF
--- a/keepmenu
+++ b/keepmenu
@@ -3,6 +3,7 @@
 """Read and copy Keepass database entries using dmenu or rofi
 
 """
+import functools
 import configparser
 from contextlib import closing
 import errno
@@ -1325,13 +1326,7 @@ class DmenuRunner(Process):
         except AttributeError:
             pass
         self._set_timer()
-        options = ['View/Type Individual entries',
-                   'View previous entry',
-                   'Edit entries',
-                   'Add entry',
-                   'Manage groups',
-                   'Reload database',
-                   'Kill Keepmenu daemon']
+
         if CONF.has_option("database", "hide_groups"):
             hid_groups = CONF.get("database", "hide_groups").split("\n")
             # Validate ignored group names in config.ini
@@ -1345,23 +1340,26 @@ class DmenuRunner(Process):
             any(j in i.path.rstrip(i.title) for j in hid_groups)
         ]
 
-        sel = view_all_entries(options, filtered_entries)
+        options = {
+            'View/Type Individual entries':
+                functools.partial(self.menu_view_type_individual_entries, hid_groups),
+            'View previous entry': self.menu_view_previous_entry,
+            'Edit entries': self.menu_edit_entries,
+            'Add entry': self.menu_add_entry,
+            'Manage groups': self.menu_manage_groups,
+            'Reload database': self.menu_reload_database,
+            'Kill Keepmenu daemon': self.menu_kill_daemon,
+        }
+        if self.prev_entry is None:
+            del options['View previous entry']
+
+        sel = view_all_entries(list(options), filtered_entries)
         if not sel:
             return
-        if sel == options[0]:
-            self.menu_view_type_individual_entries(hid_groups)
-        elif sel == options[1]:
-            self.menu_view_previous_entry()
-        elif sel == options[2]:
-            self.menu_edit_entries()
-        elif sel == options[3]:
-            self.menu_add_entry()
-        elif sel == options[4]:
-            self.menu_manage_groups()
-        elif sel == options[5]:
-            self.menu_reload_database()
-        elif sel == options[6]:
-            self.menu_kill_daemon()
+
+        if sel in options:
+            func = options[sel]
+            func()
         else:
             try:
                 entry = filtered_entries[int(sel.split('-', 1)[0])]
@@ -1392,10 +1390,7 @@ class DmenuRunner(Process):
         """Process menu entry - View previous entry
 
         """
-        if self.prev_entry is None:
-            dmenu_err("No previous entry")
-            return
-
+        assert self.prev_entry is not None
         text = view_entry(self.prev_entry)
         type_text(text)
 

--- a/keepmenu
+++ b/keepmenu
@@ -1267,6 +1267,7 @@ class DmenuRunner(Process):
         self.server = server
         self.database = get_database()
         self.kpo = get_entries(self.database)
+        self.prev_entry = None
         if not self.kpo:
             self.server.kill_flag.set()
             sys.exit()
@@ -1325,6 +1326,7 @@ class DmenuRunner(Process):
             pass
         self._set_timer()
         options = ['View/Type Individual entries',
+                   'View previous entry',
                    'Edit entries',
                    'Add entry',
                    'Manage groups',
@@ -1349,14 +1351,16 @@ class DmenuRunner(Process):
         if sel == options[0]:
             self.menu_view_type_individual_entries(hid_groups)
         elif sel == options[1]:
-            self.menu_edit_entries()
+            self.menu_view_previous_entry()
         elif sel == options[2]:
-            self.menu_add_entry()
+            self.menu_edit_entries()
         elif sel == options[3]:
-            self.menu_manage_groups()
+            self.menu_add_entry()
         elif sel == options[4]:
-            self.menu_reload_database()
+            self.menu_manage_groups()
         elif sel == options[5]:
+            self.menu_reload_database()
+        elif sel == options[6]:
             self.menu_kill_daemon()
         else:
             try:
@@ -1364,6 +1368,7 @@ class DmenuRunner(Process):
             except (ValueError, TypeError):
                 return
             type_entry(entry)
+            self.prev_entry = entry
 
     def menu_view_type_individual_entries(self, hid_groups):
         """Process menu entry - View/Type individual entries
@@ -1381,6 +1386,18 @@ class DmenuRunner(Process):
             return
         text = view_entry(entry)
         type_text(text)
+        self.prev_entry = entry
+
+    def menu_view_previous_entry(self):
+        """Process menu entry - View previous entry
+
+        """
+        if self.prev_entry is None:
+            dmenu_err("No previous entry")
+            return
+
+        text = view_entry(self.prev_entry)
+        type_text(text)
 
     def menu_edit_entries(self):
         """Process menu entry - Edit individual entries
@@ -1397,6 +1414,7 @@ class DmenuRunner(Process):
             edit = edit_entry(self.kpo, entry)
         self.kpo.save()
         self.kpo = get_entries(self.database)
+        self.prev_entry = entry
 
     def menu_add_entry(self):
         """Process menu entry - Add entry
@@ -1406,6 +1424,7 @@ class DmenuRunner(Process):
         if entry:
             self.kpo.save()
             self.kpo = get_entries(self.database)
+            self.prev_entry = entry
 
     def menu_manage_groups(self):
         """Process menu entry - manage groups


### PR DESCRIPTION
When I'm using manual selection for an entry, I often need to visit the same entry multiple times (e.g. to type credit card number, expiry date and CVV; or when needing to re-type a password for a new account).

Thus, I added a "View previous entry" menu item which shows whatever entry was last viewed/added/edited.

In the second commit, I also refactor the menu a bit so we don't need to rely on hard-coded indices. This makes it possible to hide the "View previous entry" menu item if there is no previous entry yet. That refactoring conflicts which #72 which I hadn't noticed earlier, but I'd be happy to rebase once that's in.