### PR TITLE
Import PyKeePass lazily

### DIFF
--- a/keepmenu
+++ b/keepmenu
@@ -26,7 +26,6 @@ import re
 import webbrowser
 import construct
 from pynput import keyboard
-from pykeepass import PyKeePass
 
 try:
     # secrets only available python 3.6+
@@ -381,6 +380,7 @@ def get_entries(dbo):
         Returns: PyKeePass object
 
     """
+    from pykeepass import PyKeePass
     dbf, keyfile, password = dbo
     if dbf is None:
         return None


### PR DESCRIPTION
On my machine (a 2020 Thinkpad T14 AMD with SSD), running keepmenu takes around 2s even if it's only communicating with an existing instance:

    $ time python3 keepmenu
    python3 keepmenu  1.71s user 0.39s system 99% cpu 2.120 total

This mostly seems to come from pykeepass, via Cryptodome:

    $ time python3 -c 'import pykeepass'
    python3 -c 'import pykeepass'  1.71s user 0.40s system 99% cpu 2.119 total

    $ time python3 -c 'import Cryptodome.Cipher.AES'
    python3 -c 'import Cryptodome.Cipher.AES'  1.55s user 0.34s system 100% cpu 1.895 total

Thus, import that lazily when it's actually needed, so that subsequent invocations of keepmenu show up instantly rather than with a 2s delay.