### PR TITLE
Add support for bemenu

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 ![PyPI](https://img.shields.io/pypi/v/keepmenu)
 ![GitHub contributors](https://img.shields.io/github/contributors/firecat53/keepmenu)
 
-Fully featured Dmenu/[Rofi][2] frontend for autotype and managing of Keepass databases.
+Fully featured Dmenu/[Rofi][2]/[Bemenu][7] frontend for autotype and managing of
+Keepass databases.
 
 Inspired in part by [Passhole][3], but more dmenu and less command line focused.
 
@@ -82,3 +83,4 @@ To run tests in a venv: `make test`
 [4]: https://keepass.info/help/base/fieldrefs.html "Keepass field references"
 [5]: https://github.com/moses-palmer/pynput "pynput"
 [6]: https://keepass.info/help/base/autotype.html#autoseq "Keepass 2.x codes"
+[7]: https://github.com/Cloudef/bemenu "Bemenu"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For full installation documention see the [installation docs][docs/install.md].
 
 1. Python 3.6+
 2. [Pykeepass][1] >= 4.0.0 and [pynput][5]
-3. Dmenu or Rofi
+3. Dmenu, Rofi, or Bemenu
 4. (optional) Pinentry
 5. (optional) xdotool or ydotool (for Wayland).
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -7,7 +7,7 @@
 1. Python 3.6+.
 2. [Pykeepass][1] >= 4.0.0 and [pynput][2]. Install via pip or your
    distribution's package manager, if available.
-3. Dmenu or Rofi. Rofi configuration/theming should be done via Rofi themes.
+3. Dmenu, Rofi or Bemenu.
 4. (optional) Pinentry. Make sure to set which flavor of pinentry command to use
    in the config file.
 5. (optional) xdotool or ydotool (for Wayland). If you have a lot of Unicode
@@ -62,7 +62,7 @@ Link to the executable `venv/bin/keemenu` when assigning a keyboard shortcut.
 
 ## Wayland (wlroots - Sway)
 
-- Dmenu and Rofi work under XWayland.
+- Dmenu and Rofi work under XWayland. Bemenu can operate natively in Wayland.
 - To enable ydotool to work without sudo
     - Pick a group that one or more users
       belong to (e.g. `users`) and:
@@ -88,5 +88,6 @@ Link to the executable `venv/bin/keemenu` when assigning a keyboard shortcut.
 
             $ systemctl --user daemon-reload 
             $ systemctl --user enable --now ydotoold.service
+
 [1]: https://aur.archlinux.org/packages/keepmenu-git "Archlinux AUR"
 [2]: https://github.com/moses-palmer/pynput "pynput"

--- a/keepmenu/menu.py
+++ b/keepmenu/menu.py
@@ -37,6 +37,10 @@ def dmenu_cmd(num_lines, prompt):
         dmenu = [dmenu_command, "-p", str(prompt)]
         if obscure is True and prompt == "Password":
             dmenu.extend(["-nb", obscure_color, "-nf", obscure_color])
+    elif "bemenu" in dmenu_command:
+        dmenu = [dmenu_command, "-p", str(prompt)]
+        if obscure is True and prompt == "Password":
+            dmenu.append("-x")
     else:
         # Catchall for some other menu programs. Maybe it'll run and not fail?
         dmenu = [dmenu_command]


### PR DESCRIPTION
In addition to dmenu and rofi, support [bemenu](https://github.com/Cloudef/bemenu), a dmenu-like program that works on Wayland as well as X11.