### PR TITLE
Add -c/--config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ For full installation documention see the [installation docs][docs/install.md].
 
 ## Usage
 
-`keepmenu [-h] [-a AUTOTYPE] [-d DATABASE] [-k KEY_FILE] [-t]`
+`keepmenu [-h] [-a AUTOTYPE] [-c CONF_FILE] [-d DATABASE] [-k KEY_FILE] [-t]`
 
 - Run `keepmenu` or bind to keystroke combination.
 - Enter database path on first run.
@@ -75,6 +75,7 @@ To run tests in a venv: `make test`
 ## Development
 
 - To install keepmenu in a venv: `make`
+
 - Build man page from Markdown source: `make man`
 - Using `hatch`:
     - `hatch shell`: provies venv with editable installation.

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -8,6 +8,8 @@ you for database and keyfile locations and save them in a default config file.
 OR Copy config.ini.example to ~/.config/keepmenu/config.ini and use it as a
 reference for additional options.
 
+Alternatively you can specify the file path to your config.ini using the -c/--config flag.
+
 #### Config.ini values
 
 | Section                   | Key                          | Default                                 | Notes                                                        |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -12,15 +12,17 @@
 
 ## CLI Options
 
-`keepmenu [-h] [-a AUTOTYPE] [-d DATABASE] [-k KEY_FILE]`
+`keepmenu [-h] [-a AUTOTYPE] [-c CONF_FILE] [-d DATABASE] [-k KEY_FILE]`
 
 --help, -h Output a usage message and exit.
 
 -a AUTOTYPE, --autotype AUTOTYPE Override autotype sequence in config.ini
 
+-c CONF_FILE, --config CONF_FILE File path to a config file
+
 -d DATABASE, --database DATABASE File path to a database to open, skipping the database selection menu
 
--k KEYFILE, --keyfile KEY_FILE File path of the keyfile needed to open the database specified by --database/-d
+-k KEY_FILE, --keyfile KEY_FILE File path of the keyfile needed to open the database specified by --database/-d
 
 ## Features
 

--- a/keepmenu.1
+++ b/keepmenu.1
@@ -23,9 +23,9 @@ keepmenu - Fully featured Dmenu/Rofi frontend for autotype and managing
 of Keepass databases.
 .SH SYNOPSIS
 .PP
-\f[B]keepmenu\f[R] [\f[B]\[en]database\f[R] file]
-[\f[B]\[en]keyfile\f[R] file] [\f[B]\[en]autotype\f[R] pattern]
-[\f[B]\[en]totp\f[R]]
+\f[B]keepmenu\f[R] [\f[B]\[en]autotype\f[R] pattern]
+[\f[B]\[en]config\f[R] file] [\f[B]\[en]database\f[R] file]
+[\f[B]\[en]keyfile\f[R] file] [\f[B]\[en]totp\f[R]]
 .SH DESCRIPTION
 .PP
 \f[B]Keepmenu\f[R] is a fast and minimal application to facilitate
@@ -34,13 +34,15 @@ It is inspired in part by Passhole, but is more dmenu and less command
 line focused.
 .SH OPTIONS
 .PP
-\f[B]-d\f[R], \f[B]\[en]database\f[R] Path to Keepass database
-.PP
-\f[B]-k\f[R], \f[B]\[en]keyfile\f[R] Path to keyfile
-.PP
 \f[B]-a\f[R], \f[B]\[en]autotype\f[R] Autotype sequence from
 https://keepass.info/help/base/autotype.html#autoseq .
 Overrides global default from config.ini for current database.
+.PP
+\f[B]-c\f[R], \f[B]\[en]config\f[R] Path to config file
+.PP
+\f[B]-d\f[R], \f[B]\[en]database\f[R] Path to Keepass database
+.PP
+\f[B]-k\f[R], \f[B]\[en]keyfile\f[R] Path to keyfile
 .PP
 \f[B]-t\f[R], \f[B]\[en]totp\f[R] TOTP mode
 .SH EXAMPLES
@@ -49,6 +51,7 @@ Overrides global default from config.ini for current database.
 \f[C]
 keepmenu
 keepmenu -t
+keepmenu -c /etc/keepmenu/config.ini
 keepmenu -d \[ti]/docs/totp_passwords.kdbx -a \[aq]{TOTP}{ENTER}\[aq]
 keepmenu -d \[ti]/passwords.kdbx -k \[ti]/passwords.keyfile -a \[aq]{S:security question}{ENTER}\[aq]
 \f[R]
@@ -61,6 +64,9 @@ config file.
 .PP
 OR Copy config.ini.example to \[ti]/.config/keepmenu/config.ini and use
 it as a reference for additional options.
+.PP
+Alternatively you can specify the file path to your config.ini using the
+-c/\[en]config flag.
 .SS config.ini options and defaults
 .PP
 .TS

--- a/keepmenu.1.md
+++ b/keepmenu.1.md
@@ -12,7 +12,7 @@ keepmenu - Fully featured Dmenu/Rofi frontend for autotype and managing of Keepa
 
 # SYNOPSIS
 
-**keepmenu** [**--database** file] [**--keyfile** file] [**--autotype** pattern] [**--totp**]
+**keepmenu** [**--autotype** pattern] [**--config** file] [**--database** file] [**--keyfile** file] [**--totp**]
 
 # DESCRIPTION
 
@@ -22,11 +22,13 @@ Passhole, but is more dmenu and less command line focused.
 
 # OPTIONS
 
+**-a**, **--autotype**  Autotype sequence from https://keepass.info/help/base/autotype.html#autoseq . Overrides global default from config.ini for current database.
+
+**-c**, **--config**   Path to config file
+
 **-d**, **--database** Path to Keepass database
 
 **-k**, **--keyfile**  Path to keyfile
-
-**-a**, **--autotype**  Autotype sequence from https://keepass.info/help/base/autotype.html#autoseq . Overrides global default from config.ini for current database.
 
 **-t**, **--totp**  TOTP mode
 
@@ -34,6 +36,7 @@ Passhole, but is more dmenu and less command line focused.
 
     keepmenu
     keepmenu -t
+    keepmenu -c /etc/keepmenu/config.ini
     keepmenu -d ~/docs/totp_passwords.kdbx -a '{TOTP}{ENTER}'
     keepmenu -d ~/passwords.kdbx -k ~/passwords.keyfile -a '{S:security question}{ENTER}'
 
@@ -44,6 +47,8 @@ you for database and keyfile locations and save them in a default config file.
 
 OR Copy config.ini.example to ~/.config/keepmenu/config.ini and use it as a
 reference for additional options.
+
+Alternatively you can specify the file path to your config.ini using the -c/--config flag.
 
 ## config.ini options and defaults
 

--- a/keepmenu/__init__.py
+++ b/keepmenu/__init__.py
@@ -34,8 +34,10 @@ MAX_LEN = 24
 CONF = configparser.ConfigParser()
 
 
-def reload_config():  # pylint: disable=too-many-statements,too-many-branches
-    """Reload config file. Primarly for use with tests.
+def reload_config(conf_file = None):  # pylint: disable=too-many-statements,too-many-branches
+    """Reload config file. Primarly for use with tests and the --config flag.
+
+    Args: conf_file - os.path
 
     """
     # pragma pylint: disable=global-statement,global-variable-not-assigned
@@ -48,12 +50,13 @@ def reload_config():  # pylint: disable=too-many-statements,too-many-branches
         SEQUENCE
     # pragma pylint: enable=global-variable-undefined,global-variable-not-assigned
     CONF = configparser.ConfigParser()
-    if not exists(CONF_FILE):
+    conf_file = conf_file if conf_file is not None else CONF_FILE
+    if not exists(conf_file):
         try:
-            os.mkdir(os.path.dirname(CONF_FILE))
+            os.mkdir(os.path.dirname(conf_file))
         except OSError:
             pass
-        with open(CONF_FILE, 'w', encoding=ENC) as conf_file:
+        with open(conf_file, 'w', encoding=ENC) as cfile:
             CONF.add_section('dmenu')
             CONF.set('dmenu', 'dmenu_command', 'dmenu')
             CONF.add_section('dmenu_passphrase')
@@ -64,9 +67,9 @@ def reload_config():  # pylint: disable=too-many-statements,too-many-branches
             CONF.set('database', 'keyfile_1', '')
             CONF.set('database', 'pw_cache_period_min', str(CACHE_PERIOD_DEFAULT_MIN))
             CONF.set('database', 'autotype_default', SEQUENCE)
-            CONF.write(conf_file)
+            CONF.write(cfile)
     try:
-        CONF.read(CONF_FILE)
+        CONF.read(conf_file)
     except configparser.ParsingError as err:
         dmenu_err(f"Config file error: {err}")
         sys.exit()
@@ -105,8 +108,5 @@ def reload_config():  # pylint: disable=too-many-statements,too-many-branches
                 dmenu_err("wtype not installed.\n"
                           "Please install or remove that option from config.ini")
                 sys.exit()
-
-
-reload_config()
 
 # vim: set et ts=4 sw=4 :

--- a/keepmenu/__main__.py
+++ b/keepmenu/__main__.py
@@ -153,6 +153,14 @@ def main():
     )
 
     parser.add_argument(
+        "-c",
+        "--config",
+        type=str,
+        required=False,
+        help="File path to a config file",
+    )
+
+    parser.add_argument(
         "-d",
         "--database",
         type=str,

--- a/keepmenu/keepmenu.py
+++ b/keepmenu/keepmenu.py
@@ -280,6 +280,8 @@ class DmenuRunner(Process):
 
     def __init__(self, server, **kwargs):
         Process.__init__(self)
+        cfile = kwargs.get('config')
+        keepmenu.reload_config(None if cfile is None else expanduser(cfile))
         self.server = server
         self.database, self.open_databases = get_database(**kwargs)
         if self.database:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -96,6 +96,20 @@ class TestFunctions(unittest.TestCase):
     def tearDown(self):
         rmtree(self.tmpdir)
 
+    def test_config_option(self):
+        self.tmpdir = tempfile.mkdtemp()
+        # First test default config
+        KM.reload_config(os.path.join(self.tmpdir, "config.ini"))
+        self.assertTrue(KM.menu.dmenu_cmd(10, "Entries") == ["dmenu", "-p", "Entries", "-l", "10"])
+        # Test full config
+        copyfile("tests/keepmenu-config.ini", os.path.join(self.tmpdir, "keepmenu-config.ini"))
+        KM.reload_config(os.path.join(self.tmpdir, "keepmenu-config.ini"))
+        self.assertTrue(KM.CONF.get("database", "database_1") == "test.kdbx")
+        res = ["/usr/bin/dmenu", "-nb", "#222222", "-nf", "#222222", "-i", "-l",
+               "10", "-fn", "Inconsolata-12", "-nb", "#909090", "-nf",
+               "#999999", "-b", "-p", "Password", "-l", "20"]
+        self.assertTrue(KM.menu.dmenu_cmd(20, "Password") == res)
+
     def test_get_password_conf(self):
         """Test proper reading of password config names with spaces
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -97,7 +97,6 @@ class TestFunctions(unittest.TestCase):
         rmtree(self.tmpdir)
 
     def test_config_option(self):
-        self.tmpdir = tempfile.mkdtemp()
         # First test default config
         KM.reload_config(os.path.join(self.tmpdir, "config.ini"))
         self.assertTrue(KM.menu.dmenu_cmd(10, "Entries") == ["dmenu", "-p", "Entries", "-l", "10"])
@@ -309,6 +308,7 @@ class TestFunctions(unittest.TestCase):
         db_name = os.path.join(self.tmpdir, "test.kdbx")
         copyfile("tests/test.kdbx", db_name)
         copyfile("tests/keepmenu-config.ini", KM.CONF_FILE)
+        KM.reload_config()
         with open(KM.CONF_FILE, 'w', encoding=KM.ENC) as conf_file:
             KM.CONF.set('database', 'database_1', db_name)
             KM.CONF.set('database', 'password_1', "password")


### PR DESCRIPTION
Currently there is no way to specify the config location.

This PR adds the command line option ( -c/--config path/to/config ) to read the specified config file on startup.
Omitting this option leads to previous behavior ( reading from ~/.config/keepmenu/config.ini ).
Paths using " ~ " ( e.g. ~/path/to/config ) are allowed.