### PR TITLE
use '127.0.0.1' instead of 'localhost'

### DIFF
--- a/keepmenu/__main__.py
+++ b/keepmenu/__main__.py
@@ -33,7 +33,7 @@ def port_in_use(port):
 
     """
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        return s.connect_ex(('localhost', port)) == 0
+        return s.connect_ex(('127.0.0.1', port)) == 0
 
 def get_auth():
     """Generate and save port and authkey to ~/.cache/.keepmenu-auth


### PR DESCRIPTION
No need to lookup for `localhost` hostname.

Also in some cases it prevents you from using it with Firejail with the network disabled, e.g.:
`firejail --net=none keepmenu`