### PR TITLE
Add Tofi support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![PyPI](https://img.shields.io/pypi/v/keepmenu)
 ![GitHub contributors](https://img.shields.io/github/contributors/firecat53/keepmenu)
 
-Fully featured [Bemenu][7]/Dmenu/[Wmenu][14]/[Fuzzel][13]/[Rofi][2]//[Wofi][8]/[Yofi][9] frontend for
+Fully featured [Bemenu][7]/Dmenu/[Wmenu][14]/[Fuzzel][13]/[Rofi][2]/[Tofi][]/[Wofi][8]/[Yofi][9] frontend for
 autotype and managing of Keepass databases.
 
 Inspired in part by [Passhole][3], but more dmenu and less command line focused.
@@ -26,7 +26,7 @@ For full installation documention see the [installation docs][docs/install.md].
 
 1. Python 3.7+
 2. [Pykeepass][1] >= 4.0.0 and [pynput][5]
-3. Bemenu, Dmenu, Wmenu, Fuzzel, Rofi, Wofi, or Yofi
+3. Bemenu, Dmenu, Wmenu, Fuzzel, Rofi, Tofi, Wofi, or Yofi
 4. xsel or wl-copy
 5. (optional) Pinentry
 6. (optional) xdotool (for X), [ydotool][10] or [wtype][11](for Wayland), [dotool][12] (X or Wayland).
@@ -97,3 +97,4 @@ To run tests in a venv: `make test`
 [12]: https://git.sr.ht/~geb/dotool "Dotool"
 [13]: https://codeberg.org/dnkl/fuzzel "Fuzzel"
 [14]: https://git.sr.ht/~adnano/wmenu "wmenu"
+[15]: https://github.com/philj56/tofi "Tofi"

--- a/docs/install.md
+++ b/docs/install.md
@@ -7,7 +7,7 @@
 1. Python 3.7+.
 2. [Pykeepass][1] >= 4.0.0 and [pynput][2]. Install via pip or your
    distribution's package manager, if available.
-3. Bemenu, Dmenu, Wmenu, Fuzzel, Rofi, Wofi, or Yofi.
+3. Bemenu, Dmenu, Wmenu, Fuzzel, Rofi, Tofi, Wofi, or Yofi.
 4. (optional) Pinentry. Make sure to set which flavor of pinentry command to use
    in the config file.
 5. (optional) xdotool (for X) or ydotool (>=1.0.0, for Wayland), wtype (for
@@ -100,6 +100,7 @@ Link to the executable `venv/bin/keemenu` when assigning a keyboard shortcut.
 | Fuzzel         | No  | Yes                         | Yes                  | No               |                 |
 | Rofi           | Yes | Yes                         | No                   | No               |                 |
 | Bemenu         | Yes | Yes                         | Yes                  | No               |                 |
+| Tofi           | No  | Yes                         | Yes                  | No               |                 |
 | Wofi           | No  | Yes                         | Yes                  | Yes              |                 |
 | Yofi           | No  | Yes                         | Yes                  | Yes              |                 |
 | *Typing Tools* |     |                             |                      |                  |                 |

--- a/keepmenu/menu.py
+++ b/keepmenu/menu.py
@@ -21,6 +21,7 @@ def dmenu_cmd(num_lines, prompt):
                 "dmenu": ["-p", str(prompt), "-l", str(num_lines)],
                 "wmenu": ["-p", str(prompt), "-l", str(num_lines)],
                 "rofi": ["-dmenu", "-p", str(prompt), "-l", str(num_lines)],
+                "tofi": ["--prompt-text={}: ".format(str(prompt)), "--num-results={}".format(str(num_lines))],
                 "wofi": ["--dmenu", "-p", str(prompt), "-L", str(num_lines + 1)],
                 "yofi": ["-p", str(prompt), "dialog"],
                 "fuzzel": ["-p", str(prompt) + " ", "-l", str(num_lines)]}
@@ -33,6 +34,7 @@ def dmenu_cmd(num_lines, prompt):
                         "wmenu": dmenu_pass(basename(command[0])),
                         "rofi": ['-password'],
                         "bemenu": ['-x', 'indicator', '*'],
+                        "tofi": ["--hide-input=true", "--require-match=false", "--hidden-character=*"],
                         "wofi": ['-P'],
                         "yofi": ['--password'],
                         "fuzzel": ['--password']}


### PR DESCRIPTION
Tofi launcher support:

![image](https://github.com/firecat53/keepmenu/assets/34678/6f7bbb22-abc0-4a93-b952-f4740a093714)

![2024-07-03-204055_hyprshot](https://github.com/firecat53/keepmenu/assets/34678/f878038c-cd9e-4ef1-b678-4d5eb5a10b8f)


Styling is supplied via config file to `dmenu_command`. Being able to supply separate styling for password window and menu window would be handy but this works fine.