### PR TITLE
Added ydotool_key_delay config option

### DIFF
--- a/config.ini.example
+++ b/config.ini.example
@@ -30,6 +30,7 @@
 # terminal = <xterm, urxvt> <options if necessary>. 'xterm' by default
 # gui_editor = <path/to/editor> <options>  e.g. gui_editor = gvim -f
 # type_library = pynput (default), xdotool (for alternate keyboard layout support), ydotool (for Wayland), wtype (also for Wayland), dotool, or dotoolc (dotool client for dotoold daemon)
+# ydotool_key_delay = <milliseconds>  delay between keystrokes for ydotool (default: ydotool's built-in default)
 # hide_groups = Recycle Bin  <Note formatting for adding multiple groups>
 #               Group 2
 #               Group 3

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -29,6 +29,7 @@ Alternatively you can specify the file path to your config.ini using the -c/--co
 |                           | `terminal`                   | `xterm`                                 |                                                              |
 |                           | `gui_editor`                 | None                                    |                                                              |
 |                           | `type_library`               | `pynput`                                | xdotool, ydotool, wtype, dotool, dotoolc or pynput           |
+|                           | `ydotool_key_delay`          | None                                    | Delay between keystrokes in ms (ydotool only)                |
 |                           | `hide_groups`                | None                                    | See below for formatting of multiple groups                  |
 |                           | `autotype_default`           | `{USERNAME}{TAB}{PASSWORD}{ENTER}`      | [Keepass autotype sequences][1]                              |
 |                           | `type_url`                   | `False`                                 |                                                              |

--- a/keepmenu/type.py
+++ b/keepmenu/type.py
@@ -254,6 +254,18 @@ def type_entry_xdotool(entry, tokens):
             call(['xdotool', 'type', '--', token])
 
 
+def _ydotool_type(to_type):
+    """Type a string using ydotool with optional --key-delay
+
+    """
+    cmd = ['ydotool', 'type', '-e', '0']
+    key_delay = keepmenu.CONF.get('database', 'ydotool_key_delay', fallback=None)
+    if key_delay is not None:
+        cmd.extend(['--key-delay', key_delay])
+    cmd.extend(['--', to_type])
+    call(cmd)
+
+
 def type_entry_ydotool(entry, tokens):
     """Auto-type entry entry using ydotool
 
@@ -265,14 +277,14 @@ def type_entry_ydotool(entry, tokens):
             if callable(cmd):
                 to_type = cmd(entry)  # pylint: disable=not-callable
                 if to_type is not None:
-                    call(['ydotool', 'type', '-e', '0', '--', to_type])
+                    _ydotool_type(to_type)
             elif token in PLACEHOLDER_AUTOTYPE_TOKENS:
                 to_type = PLACEHOLDER_AUTOTYPE_TOKENS[token](entry)
                 if to_type:
-                    call(['ydotool', 'type', '-e', '0', '--', to_type])
+                    _ydotool_type(to_type)
             elif token in STRING_AUTOTYPE_TOKENS:
                 to_type = STRING_AUTOTYPE_TOKENS[token]
-                call(['ydotool', 'type', '-e', '0', '--', to_type])
+                _ydotool_type(to_type)
             elif token in AUTOTYPE_TOKENS:
                 cmd = ['ydotool'] + AUTOTYPE_TOKENS[token]
                 call(cmd)
@@ -280,7 +292,7 @@ def type_entry_ydotool(entry, tokens):
                 dmenu_err(f"Unsupported auto-type token (ydotool): \"{token}\"")
                 return
         else:
-            call(['ydotool', 'type', '-e', '0', '--', token])
+            _ydotool_type(token)
 
 
 def type_entry_wtype(entry, tokens):
@@ -383,7 +395,7 @@ def type_text(data):
     if library == 'xdotool':
         call(['xdotool', 'type', '--', data])
     elif library == 'ydotool':
-        call(['ydotool', 'type', '-e', '0', '--', data])
+        _ydotool_type(data)
     elif library == 'wtype':
         call(['wtype', '--', data])
     elif library == 'dotool':


### PR DESCRIPTION
Hello! I've been using `keepmenu` for a while now and love it. I recently switched to using `ydotool` after `wtype` was not working consistently for me, and I found that the default `--key-delay` is a bit long. There's no way to set a different default key delay for ydotool, unfortunately, so I added the ability to pass in a custom `--key-delay` here.